### PR TITLE
feat : 회원 엔티티 생성

### DIFF
--- a/user-service/src/main/java/com/wesell/userservice/domain/entity/User.java
+++ b/user-service/src/main/java/com/wesell/userservice/domain/entity/User.java
@@ -1,0 +1,52 @@
+package com.wesell.userservice.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.DynamicInsert;
+
+import java.util.Date;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@RequiredArgsConstructor
+@AllArgsConstructor
+@ToString
+@Builder
+@DynamicInsert
+public class User {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "u_id")
+    private Long id;
+
+    @Column(name = "u_name", nullable = false)
+    private String name;
+
+    @Column(name = "u_nickname", length = 15, nullable = false)
+    private String nickname;
+
+    @Column(name = "u_phone", length = 11, nullable = false)
+    private String phone;
+
+    @CreationTimestamp
+    @Column(name = "u_createdAt", nullable = false)
+    private Date createdAt;
+
+    @ColumnDefault(value = "false")
+    @Column(name = "u_isforced", nullable = false)
+    private boolean isforced;
+
+    @ColumnDefault(value = "false")
+    @Column(name = "u_agree", nullable = false)
+    private boolean agree;
+
+    @Column(name = "u_uuid", nullable = false)
+    private String uuid;
+
+
+}

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -17,6 +17,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        check_nullability: true
     show_sql: true
 
   profiles:


### PR DESCRIPTION
* 회원 엔티티 생성했습니다

- @ColumnDefault로 컬럼의 기본값을 설정해줄수있고 @DynamicInsert로 insert문 실행 시 null이 아닌 컬럼들만 포함할 수 있습니다.
- Enum은 인증/인가 서버에서 구현하게 되어서 회원 도메인에서는 제외하였습니다.
- 생성일자는 @CreationTimestamp로 자동생성할수 있게 구현하였습니다.