### PR TITLE
fix: 회원 엔티티 수정2

### DIFF
--- a/user-service/src/main/java/com/wesell/userservice/domain/entity/User.java
+++ b/user-service/src/main/java/com/wesell/userservice/domain/entity/User.java
@@ -12,6 +12,7 @@ import java.util.Date;
 @Entity
 @ToString
 @Builder
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicInsert

--- a/user-service/src/main/java/com/wesell/userservice/domain/entity/User.java
+++ b/user-service/src/main/java/com/wesell/userservice/domain/entity/User.java
@@ -1,0 +1,52 @@
+package com.wesell.userservice.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.DynamicInsert;
+
+import java.util.Date;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@RequiredArgsConstructor
+@AllArgsConstructor
+@ToString
+@Builder
+@DynamicInsert
+public class User {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "u_id")
+    private Long id;
+
+    @Column(name = "u_name", nullable = false)
+    private String name;
+
+    @Column(name = "u_nickname", length = 15, nullable = false)
+    private String nickname;
+
+    @Column(name = "u_phone", length = 11, nullable = false)
+    private String phone;
+
+    @CreationTimestamp
+    @Column(name = "u_createdAt", nullable = false)
+    private Date createdAt;
+
+    @ColumnDefault(value = "false")
+    @Column(name = "u_isforced", nullable = false)
+    private boolean isforced;
+
+    @ColumnDefault(value = "false")
+    @Column(name = "u_agree", nullable = false)
+    private boolean agree;
+
+    @Column(name = "u_uuid", nullable = false)
+    private String uuid;
+
+
+}

--- a/user-service/src/main/java/com/wesell/userservice/domain/entity/User.java
+++ b/user-service/src/main/java/com/wesell/userservice/domain/entity/User.java
@@ -6,17 +6,16 @@ import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.DynamicInsert;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 @Entity
-@Getter
-@Setter
-@NoArgsConstructor
-@RequiredArgsConstructor
-@AllArgsConstructor
 @ToString
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicInsert
+@Table(name = "user")
 public class User {
 
     @Id
@@ -30,12 +29,12 @@ public class User {
     @Column(name = "u_nickname", length = 15, nullable = false)
     private String nickname;
 
-    @Column(name = "u_phone", length = 11, nullable = false)
+    @Column(name = "u_phone", nullable = false)
     private String phone;
 
     @CreationTimestamp
     @Column(name = "u_createdAt", nullable = false)
-    private Date createdAt;
+    private LocalDateTime createdAt;
 
     @ColumnDefault(value = "false")
     @Column(name = "u_isforced", nullable = false)
@@ -47,6 +46,5 @@ public class User {
 
     @Column(name = "u_uuid", nullable = false)
     private String uuid;
-
 
 }

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -17,6 +17,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        check_nullability: true
     show_sql: true
 
   profiles:


### PR DESCRIPTION
* 회원 엔티티 수정
- 객체의 변경점을 줄이고 객체의 일관성을 유지하기 위해 기본 생성자에 AccessLevel을 설정하고 접근제어자를 PROTECTED로 하였습니다.
- Setter가 아닌 생성자를 통해 주입받아서 필드값이 외부에서 무분별하게 설정되는 것을 방지하였고 @builder, @NoArgsConstructor, @AllArgsConstructor를 같이 사용해서 모든 필드에 대해 생성자를 설정할 수 있게 되었습니다.
- 이외에 다른 수정요구사항에 대해서는 @table을 통해 name을 user로 설정하였고 phone 필드에 대해서는 굳이 바꾸지 않아도 다른 필드에 phone이라는 필드가 없기 때문에 직관적으로 이해할 수 있을 것 같아서 필드명은 바꾸지 않았습니다.
- 빠진 @Getter를 추가하였습니다.