### PR TITLE
feat: spring-security 설정

### DIFF
--- a/authentication-server/src/main/java/com/wesell/authenticationserver/domain/entity/Authentication.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/domain/entity/Authentication.java
@@ -7,7 +7,8 @@ import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter @Builder
-@NoArgsConstructor @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Table(name="auth")
 public class Authentication {
 

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/global/config/SecurityConfig.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/global/config/SecurityConfig.java
@@ -1,0 +1,49 @@
+package com.wesell.authenticationserver.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    /**
+     * 인증 인가 과정을 거치지 않도록 처리한 설정 - swagger
+     * @return return WebSecurityCustomizer
+     */
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer(){
+        return web -> web.ignoring().requestMatchers("/v2/api-docs"
+                ,"/swagger-resources/**","/swagger-ui.html","/swagger/**");
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http)throws Exception{
+        http
+                // CSRF 설정
+                .csrf(AbstractHttpConfigurer::disable)
+
+                // JWT 토큰을 사용하기 때문에 Session을 사용하지 않도록 설정
+                .sessionManagement(sessionConfig -> sessionConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // 권한 확인 설정 - 추후 세부적으로 구분 예정
+                .authorizeHttpRequests(authorizationConfig->{
+                    authorizationConfig.anyRequest().permitAll();
+                })
+
+                // 인증/인가 중 예외 발생 시 전달
+
+                // X-Frame-Options 헤더 비활성화 - 보안 측면(디도스 방지)
+                .headers(headers -> headers
+                        .frameOptions(HeadersConfigurer.FrameOptionsConfig::disable)
+                );
+
+        return http.build();
+    }
+
+}

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/global/config/SwaggerConfig.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/global/config/SwaggerConfig.java
@@ -1,0 +1,45 @@
+package com.wesell.authenticationserver.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class SwaggerConfig {
+
+    // 버전 정보
+    private final String VERSION = "v0.0.1";
+
+    // 제목
+    private final String TITLE = "\" AUTH SERVER API 명세서 \"";
+
+    //설명
+    private final String DESCRIPTION = "AUTH SERVER 관련 API 명세서 입니다."
+            +"인증 및 인가 관련된 요청을 처리합니다.";
+
+    /**
+     * Swagger API 설정
+     * @return
+     */
+    @Bean
+    public OpenAPI openAPI(){
+        return new OpenAPI()
+                .components(new Components())
+                .info(swaggerInfo());
+    }
+
+    /**
+     * Swagger UI 기본 정보 설정
+     * @return Info()
+     */
+    private Info swaggerInfo(){
+        return new Info()
+                .version(VERSION)
+                .title(TITLE)
+                .description(DESCRIPTION);
+    }
+}

--- a/authentication-server/src/main/resources/application.yml
+++ b/authentication-server/src/main/resources/application.yml
@@ -24,7 +24,7 @@ spring:
     active: db
 
 springdoc:
-  packages-to-scan: com.test.swaggertest.controllers
+  packages-to-scan: com.wesell.authenticationserver.controller
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
   swagger-ui:


### PR DESCRIPTION
🎇 feat: Swagger 설정 & fix: Swagger 설정 수정
- Config 파일 생성하여 Swagger-ui 설정 추가했습니다.
- version, title, description 가독성을 높이기 위해서 멤버 변수로 지정하여, Config 빈 등록 시 초기화 되도록 `@RequiredArgsConstructor` 어노테이션 추가하였습니다.
- application.yml 상에 Swagger scan 범위 재설정 하였습니다.

🎇 fix: Authentication 엔티티 수정
- 회원 엔티티 참고하여 `@NoArgsConstructor` 접근 제한 설정 추가하였습니다.(엔티티 사용 외 객체의 무분별한 생성 방지)

🎇 feat: spring-security 설정
- csrf disable
- jwt 사용으로 인한 session 비활성화
- 권환을 확인하기 위한 필터 설정
- X-frame-header 비활성화