### PR TITLE
feat: 인증 서버측 회원 가입 기능 구현

### DIFF
--- a/authentication-server/build.gradle
+++ b/authentication-server/build.gradle
@@ -11,15 +11,28 @@ java {
 	sourceCompatibility = '17'
 }
 
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+}
+
 repositories {
 	mavenCentral()
 }
 
+ext {
+	set('springCloudVersion', "2022.0.4")
+}
+
 dependencies {
+
+	//Eureka-client
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
 	// Web, validation
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot.:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// Swagger
 	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.2.0'
@@ -27,6 +40,9 @@ dependencies {
 	// lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	//DB(mysql)
+	runtimeOnly 'com.mysql:mysql-connector-j:8.0.33'
 
 	// JPA
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -39,11 +55,20 @@ dependencies {
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
+	// OpenFeign
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
 	// OAuth 2.0
 
 	// Test 코드
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
 }
 
 tasks.named('test') {

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/AuthenticationServerApplication.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/AuthenticationServerApplication.java
@@ -2,8 +2,10 @@ package com.wesell.authenticationserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class AuthenticationServerApplication {
 
 	public static void main(String[] args) {

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AuthController.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AuthController.java
@@ -1,0 +1,32 @@
+package com.wesell.authenticationserver.controller;
+
+import com.wesell.authenticationserver.dto.request.CreateUserRequestDto;
+import com.wesell.authenticationserver.service.AuthUserService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraintvalidation.SupportedValidationTarget;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Log4j2
+@RequestMapping("auth-server")
+public class AuthController {
+
+    private final AuthUserService authUserService;
+
+    @PostMapping("sign-up")
+    public ResponseEntity<Void> signUp(@Valid @RequestBody CreateUserRequestDto dto){
+
+        log.debug("AuthController - 회원가입");
+
+        authUserService.createUser(dto);
+
+        return ResponseEntity.status(201).body(null);
+    }
+}

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AuthController.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AuthController.java
@@ -3,10 +3,10 @@ package com.wesell.authenticationserver.controller;
 import com.wesell.authenticationserver.dto.request.CreateUserRequestDto;
 import com.wesell.authenticationserver.service.AuthUserService;
 import jakarta.validation.Valid;
-import jakarta.validation.constraintvalidation.SupportedValidationTarget;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,6 +19,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthUserService authUserService;
+
+    @GetMapping("health-check")
+    public ResponseEntity<String> healthCheck(){
+        return ResponseEntity.ok().body("auth-server available");
+    }
 
     @PostMapping("sign-up")
     public ResponseEntity<Void> signUp(@Valid @RequestBody CreateUserRequestDto dto){

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/domain/entity/AuthUser.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/domain/entity/AuthUser.java
@@ -3,14 +3,11 @@ package com.wesell.authenticationserver.domain.entity;
 import com.wesell.authenticationserver.domain.enum_.Role;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.DynamicInsert;
 
 @Entity
 @Getter @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@DynamicInsert
 @Table(name="auth")
 public class AuthUser {
 
@@ -22,14 +19,13 @@ public class AuthUser {
     @Column(name = "a_email", nullable = false, unique = true, length = 60)
     private String email;
 
-    @Column(name= "a_password", length = 30)
+    @Column(name= "a_password", length = 100)
     private String password;
 
-    @Column(name="a_uuid", nullable = false, length = 20)
+    @Column(name="a_uuid", nullable = false, length = 50)
     private String uuid;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    @ColumnDefault(value = "USER")
     private Role role;
 }

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/domain/entity/AuthUser.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/domain/entity/AuthUser.java
@@ -10,7 +10,7 @@ import org.hibernate.annotations.ColumnDefault;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name="auth")
-public class Authentication {
+public class AuthUser {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/domain/entity/AuthUser.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/domain/entity/AuthUser.java
@@ -4,11 +4,13 @@ import com.wesell.authenticationserver.domain.enum_.Role;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 
 @Entity
 @Getter @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@DynamicInsert
 @Table(name="auth")
 public class AuthUser {
 

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/domain/repository/AuthRepository.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/domain/repository/AuthRepository.java
@@ -1,7 +1,0 @@
-package com.wesell.authenticationserver.domain.repository;
-
-import com.wesell.authenticationserver.domain.entity.Authentication;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface AuthRepository extends JpaRepository<Authentication, Long> {
-}

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/domain/repository/AuthUserRepository.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/domain/repository/AuthUserRepository.java
@@ -1,0 +1,7 @@
+package com.wesell.authenticationserver.domain.repository;
+
+import com.wesell.authenticationserver.domain.entity.AuthUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuthUserRepository extends JpaRepository<AuthUser, Long> {
+}

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/dto/request/CreateUserRequestDto.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/dto/request/CreateUserRequestDto.java
@@ -1,6 +1,7 @@
 package com.wesell.authenticationserver.dto.request;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
@@ -30,6 +31,7 @@ public class CreateUserRequestDto { // 회원가입(front) -> Auth-Server
 
     @NotBlank(message = "이름을 입력해주세요.")
     @Pattern(regexp = "^[가-힣]+$", message = "이름은 한글로 작성해주세요.")
+    @Size(min = 2, message= "이름은 2자 이상 입력하세요.")
     private String name; // 회원명
 
     @NotBlank(message = "닉네임을 입력해주세요.")
@@ -37,12 +39,13 @@ public class CreateUserRequestDto { // 회원가입(front) -> Auth-Server
     private String nickname; // 닉네임
 
     @NotBlank(message = "휴대전화 번호를 입력해주세요.")
-    @Pattern(regexp = "^01(0|1|[6-8])\\\\d{3,4}\\\\d{4}$")
+    @Pattern(regexp = "^01(0|1|[6-8])\\d{3,4}\\d{4}$", message="휴대전화 번호 양식이 아닙니다.")
     private String phone; // 휴대전화 번호
 
     @AssertTrue(message = "개인 정보 제공에 동의 해주세요.")
     private boolean agree; // 개인정보 제공 동의여부
-    
+
+    @JsonIgnore
     private String uuid; // 회원 구분 번호
 
 }

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/dto/request/CreateUserRequestDto.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/dto/request/CreateUserRequestDto.java
@@ -1,0 +1,48 @@
+package com.wesell.authenticationserver.dto.request;
+
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class CreateUserRequestDto { // 회원가입(front) -> Auth-Server
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "이메일 양식이 아닙니다.")
+    private String email; // 이메일
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Size(min = 8,max = 16,message = "비밀번호를 8자 이상 16자 이하로 입력하세요.")
+    private String pw; // 비밀번호
+
+    @NotBlank(message = "비밀번호를 확인해주세요.")
+    private String pwRe; // 비밀번호 확인
+
+    @NotBlank(message = "이름을 입력해주세요.")
+    @Pattern(regexp = "^[가-힣]+$", message = "이름은 한글로 작성해주세요.")
+    private String name; // 회원명
+
+    @NotBlank(message = "닉네임을 입력해주세요.")
+    @Size(min = 1, max = 15, message = "닉네임은 1자이상 15자 이하로 입력하세요.")
+    private String nickname; // 닉네임
+
+    @NotBlank(message = "휴대전화 번호를 입력해주세요.")
+    @Pattern(regexp = "^01(0|1|[6-8])\\\\d{3,4}\\\\d{4}$")
+    private String phone; // 휴대전화 번호
+
+    @AssertTrue(message = "개인 정보 제공에 동의 해주세요.")
+    private boolean agree; // 개인정보 제공 동의여부
+    
+    private String uuid; // 회원 구분 번호
+
+}

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/dto/response/CreateUserFeignResponseDto.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/dto/response/CreateUserFeignResponseDto.java
@@ -1,0 +1,27 @@
+package com.wesell.authenticationserver.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class CreateUserFeignResponseDto {
+
+    private String name; // 회원명
+
+    private String nickname; // 닉네임
+
+    private String phone; // 휴대전화 번호
+
+    private boolean agree; // 개인정보 제공 동의여부
+
+    private String uuid; // 회원 구분 번호
+}

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/error/ErrorCode.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/error/ErrorCode.java
@@ -1,0 +1,33 @@
+package com.wesell.authenticationserver.error;
+
+import lombok.Getter;
+
+/**
+ * 예외 일괄 처리 : 커스텀 에러코드  - 구현중
+ */
+@Getter
+public enum ErrorCode {
+
+    /**
+     * common
+     */
+    INVALID_REQUEST(400,"C001","유효하지 않은 요청입니다."),
+    INVALID_RESPONSE(400,"C002","유효하지 않은 응답입니다."),
+    NOT_FOUND_RESOURCE(404,"C003","찾을 수 없는 리소스입니다."),
+    TEMPORARY_SERVER_ERROR(400,"C004","일시적으로 서버 내 오류가 발생했습니다.");
+
+    /**
+     *  user
+     */
+
+
+    private final int status; // 상태코드(숫자)
+    private final String code; // 커스텀 코드(서버 내 관리하는 에러 코드)
+    private final String message; // 에러 발생 시 메시지
+
+    private ErrorCode(int status, String code, String message){
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/error/ErrorControllerAdvisor.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/error/ErrorControllerAdvisor.java
@@ -1,0 +1,31 @@
+package com.wesell.authenticationserver.error;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ErrorControllerAdvisor {
+
+    /**
+     * springframework.validation 에러 메시지 처리
+     * @return ResponseEntity<String>
+     */
+    @ExceptionHandler(BindException.class)
+    protected ResponseEntity<String> handlerException(BindException e){
+
+        StringBuilder errorMessage = new StringBuilder("필수 입력 항목을 전부 입력해주세요! : \n");
+
+        for (FieldError fieldError : e.getFieldErrors()) {
+            errorMessage.append(fieldError.getField())
+                    .append(" - ")
+                    .append(fieldError.getDefaultMessage())
+                    .append("\n");
+        }
+
+        return ResponseEntity.status(400).body(errorMessage.toString());
+
+    }
+}

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/error/ErrorResponseDto.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/error/ErrorResponseDto.java
@@ -1,0 +1,28 @@
+package com.wesell.authenticationserver.error;
+
+import lombok.*;
+
+/**
+ * 에러 메시지 응답 dto
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class ErrorResponseDto {
+
+    private int status;
+    private String code;
+    private String message;
+    private String detail; // exception 발생 시 오류 메시지
+
+    private ErrorResponseDto(ErrorCode errorCode){
+        this.status = errorCode.getStatus();
+        this.code = errorCode.getCode();
+        this.message = errorCode.getMessage();
+    }
+
+    public static ErrorResponseDto of(ErrorCode errorCode){
+        return new ErrorResponseDto(errorCode);
+    }
+
+}

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/global/config/SecurityConfig.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -14,7 +15,7 @@ public class SecurityConfig {
 
     /**
      * 인증 인가 과정을 거치지 않도록 처리한 설정 - swagger
-     * @return return WebSecurityCustomizer
+     * @return WebSecurityCustomizer
      */
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer(){
@@ -44,6 +45,12 @@ public class SecurityConfig {
                 );
 
         return http.build();
+    }
+
+    // 비밀번호 암호화
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder(){
+        return new BCryptPasswordEncoder();
     }
 
 }

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/Converter.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/Converter.java
@@ -1,6 +1,7 @@
 package com.wesell.authenticationserver.global.util;
 
 import com.wesell.authenticationserver.domain.entity.AuthUser;
+import com.wesell.authenticationserver.domain.enum_.Role;
 import com.wesell.authenticationserver.dto.request.CreateUserRequestDto;
 import com.wesell.authenticationserver.dto.response.CreateUserFeignResponseDto;
 import org.springframework.stereotype.Component;
@@ -22,6 +23,7 @@ public class Converter {
                 .email(email)
                 .password(password)
                 .uuid(uuid)
+                .role(Role.USER)
                 .build();
     }
 

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/Converter.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/Converter.java
@@ -1,0 +1,45 @@
+package com.wesell.authenticationserver.global.util;
+
+import com.wesell.authenticationserver.domain.entity.AuthUser;
+import com.wesell.authenticationserver.dto.request.CreateUserRequestDto;
+import com.wesell.authenticationserver.dto.response.CreateUserFeignResponseDto;
+import org.springframework.stereotype.Component;
+
+// 기능 : dto <-> entity || dto <-> dto(OpenFeign 시)
+@Component
+public class Converter {
+
+    /**
+     * dto -> entity
+     */
+    public AuthUser toEntity(CreateUserRequestDto createUserRequestDto){
+
+        String email = createUserRequestDto.getEmail();
+        String password = createUserRequestDto.getPw();
+        String uuid = createUserRequestDto.getUuid();
+
+        return AuthUser.builder()
+                .email(email)
+                .password(password)
+                .uuid(uuid)
+                .build();
+    }
+
+    /*---------------------------------------------------------------------------*/
+
+    /**
+     * dto -> feignDto
+     */
+
+    public CreateUserFeignResponseDto toFeignDto(CreateUserRequestDto createUserRequestDto){
+        return CreateUserFeignResponseDto.builder()
+                .name(createUserRequestDto.getName())
+                .nickname(createUserRequestDto.getNickname())
+                .uuid(createUserRequestDto.getUuid())
+                .agree(createUserRequestDto.isAgree())
+                .phone(createUserRequestDto.getPhone())
+                .build();
+    }
+
+
+}

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/service/AuthUserService.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/service/AuthUserService.java
@@ -38,8 +38,9 @@ public class AuthUserService {
         log.debug("회원 인증 정보 - DB 저장");
         authUserRepository.save(user);
 
+        // 연동 전 테스트를 위해 주석처리
         log.debug("User-Service Api Call - 회원가입 요청");
-        CreateUserFeignResponseDto feignDto = converter.toFeignDto(createUserRequestDto);
-        userServiceFeignClient.registerUserDetailInfo(feignDto);
+//        CreateUserFeignResponseDto feignDto = converter.toFeignDto(createUserRequestDto);
+//        userServiceFeignClient.registerUserDetailInfo(feignDto);
     }
 }

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/service/AuthUserService.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/service/AuthUserService.java
@@ -1,0 +1,45 @@
+package com.wesell.authenticationserver.service;
+
+import com.wesell.authenticationserver.domain.entity.AuthUser;
+import com.wesell.authenticationserver.domain.repository.AuthUserRepository;
+import com.wesell.authenticationserver.dto.request.CreateUserRequestDto;
+import com.wesell.authenticationserver.dto.response.CreateUserFeignResponseDto;
+import com.wesell.authenticationserver.global.util.Converter;
+import com.wesell.authenticationserver.service.feign.UserServiceFeignClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class AuthUserService {
+
+    private final UserServiceFeignClient userServiceFeignClient;
+    private final AuthUserRepository authUserRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+    private final Converter converter;
+
+    /**
+     * 회원 가입 기능
+     */
+    public void createUser(CreateUserRequestDto createUserRequestDto){
+        log.debug("회원 가입 시작");
+
+        log.debug("uuid 생성, 비밀번호 암호화, 회원 인증 정보 엔티티로 convert");
+        String pw = passwordEncoder.encode(createUserRequestDto.getPw()); // 암호화
+        String uuid = UUID.randomUUID().toString();
+        createUserRequestDto.setUuid(uuid);
+        createUserRequestDto.setPw(pw);
+        AuthUser user = converter.toEntity(createUserRequestDto);
+
+        log.debug("회원 인증 정보 - DB 저장");
+        authUserRepository.save(user);
+
+        log.debug("User-Service Api Call - 회원가입 요청");
+        CreateUserFeignResponseDto feignDto = converter.toFeignDto(createUserRequestDto);
+        userServiceFeignClient.registerUserDetailInfo(feignDto);
+    }
+}

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/service/feign/UserServiceFeignClient.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/service/feign/UserServiceFeignClient.java
@@ -1,0 +1,14 @@
+package com.wesell.authenticationserver.service.feign;
+
+import com.wesell.authenticationserver.dto.response.CreateUserFeignResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name="user-service", path="user-service")
+public interface UserServiceFeignClient {
+
+    @PostMapping("api/sign-up")
+    void registerUserDetailInfo(@RequestBody CreateUserFeignResponseDto dto);
+
+}


### PR DESCRIPTION
🎇 fix: 엔티티명 & 레포지토리명 수정 & fix: 인증 인가 엔티티 수정
- 회원 인증/인가 정보를 직관적으로 표현하기 위해서 `Authentication` ➡️ `AuthUser`로 변경했습니다.

🎇 fix: 비밀번호 암호화 설정 추가
- 비밀번호 암호화를 위해 spring-security 라이브러리 내 BCryptPasswordEncoder 빈 등록.

🎇 feat: 회원가입 요청 데이터 DTO & fix: 회원가입 요청 데이터 DTO 수정(1차)
- 회원가입 요청 DTO 구현 및 일부 regex 수정

🎇 feat: 회원가입 기능 구현 및 user-service feign 요청 구현 & fix: user-service feign 수정(1차)
- 회원가입 처리 후 feign client를 사용하여 회원 상세정보를 user-service 서버로 전달

🎇 feat: dto <-> entity converter 구현!
- dto와 entity 간의 변환 기능을 하나의 class로 관리하기 위한 Coeverter 클래스 구현

🎇 feat: 회원가입 RestController 구현 & feat: auth-server health-check 구현
- swagger test를 위해 `@PostMapping`을 사용하여 RestController 구현
- auth-server health 체크를 위한 `@GetMapping` 구현

🎇 feat: Validation 에러 메시지 출력 기능 구현
- Error 메시지를 처리하기 위해 `@ExceptionHandler`를 사용하여 BindException(Validation 에러) 처리

❗ fix: 인증 인가 엔티티 Role 초기화 방식 수정
- 처음 권한을 저장하기 위해 enum을 사용하여 구현하였으나, default 값으로 사용할 User 라는 값이 enum으로 구현 시 SQL 오류가 발생하여, Builder에서 Role.USER를 추가해주는 방식으로 초기값 저장하도록 수정함.
- `@Enuumerated` 어노테이션과 `@ColumnDefault`를 함께 사용 시 오류가 발생하는 것으로 보임!

