### PR TITLE
feat: 회원 목록 조회 기능

### DIFF
--- a/admin-service/build.gradle
+++ b/admin-service/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.2.0'
 	implementation 'org.modelmapper:modelmapper:2.4.1'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.0.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/admin-service/src/main/java/com/wesell/adminservice/AdminServiceApplication.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/AdminServiceApplication.java
@@ -3,9 +3,11 @@ package com.wesell.adminservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
 @EnableDiscoveryClient
+@ComponentScan("com.wesell.adminservice.feignClient")
 public class AdminServiceApplication {
 
 	public static void main(String[] args) {

--- a/admin-service/src/main/java/com/wesell/adminservice/controller/AdminController.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/controller/AdminController.java
@@ -1,12 +1,14 @@
 package com.wesell.adminservice.controller;
 
-import com.wesell.adminservice.domain.dto.RequestAdminDto;
-import com.wesell.adminservice.domain.dto.ResponseAdminDto;
+import com.wesell.adminservice.domain.dto.SiteConfigRequestDto;
+import com.wesell.adminservice.domain.dto.SiteConfigResponseDto;
+import com.wesell.adminservice.domain.dto.UserListResponseDto;
 import com.wesell.adminservice.service.AdminService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -17,15 +19,37 @@ public class AdminController {
 
     private final AdminService adminService;
 
-    @PostMapping("set-config")
-    public ResponseEntity<ResponseAdminDto> saveSiteConfig(@RequestBody RequestAdminDto requestAdminDto) {
-        ResponseAdminDto savedSiteConfig = adminService.saveSiteConfig(requestAdminDto);
+    @PostMapping("set/config")
+    public ResponseEntity<SiteConfigResponseDto> saveSiteConfig(@RequestBody SiteConfigRequestDto siteConfigRequestDto) {
+        SiteConfigResponseDto savedSiteConfig = adminService.saveSiteConfig(siteConfigRequestDto);
         return new ResponseEntity<>(savedSiteConfig, HttpStatus.CREATED);
     }
 
-    @GetMapping("get-config")
-    public ResponseEntity<ResponseAdminDto> getSiteConfig() {
-        ResponseAdminDto currentSiteConfig = adminService.getSiteConfig();
+    @GetMapping("get/config")
+    public ResponseEntity<SiteConfigResponseDto> getSiteConfig() {
+        SiteConfigResponseDto currentSiteConfig = adminService.getSiteConfig();
         return new ResponseEntity<>(currentSiteConfig, HttpStatus.OK);
+    }
+
+
+    @GetMapping("get/user-list")
+    public ResponseEntity<UserListResponseDto> getUserList() {
+        UserListResponseDto userListResponseDto = adminService.getUserList();
+        return new ResponseEntity<>(userListResponseDto, HttpStatus.OK);
+    }
+
+    @GetMapping("version")
+    public ResponseEntity<SiteConfigResponseDto> getVersionAndSave(
+            @RequestParam(name = "jsVersion", defaultValue = "1.0") String jsVersion,
+            @RequestParam(name = "cssVersion", defaultValue = "1.0") String cssVersion,
+            @RequestParam(name = "title", defaultValue = "Default Title") String title) {
+
+        Map<String, String> versions = new HashMap<>();
+        versions.put("jsVersion", jsVersion);
+        versions.put("cssVersion", cssVersion);
+        versions.put("title", title);
+        SiteConfigRequestDto requestDto = adminService.mapToRequestAdminDto(versions);
+        SiteConfigResponseDto savedSiteConfig = adminService.saveSiteConfig(requestDto);
+        return new ResponseEntity<>(savedSiteConfig, HttpStatus.CREATED);
     }
 }

--- a/admin-service/src/main/java/com/wesell/adminservice/domain/dto/SiteConfigRequestDto.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/domain/dto/SiteConfigRequestDto.java
@@ -1,0 +1,13 @@
+package com.wesell.adminservice.domain.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class SiteConfigRequestDto {
+
+    private String jsVersion;
+    private String cssVersion;
+    private String title;
+}

--- a/admin-service/src/main/java/com/wesell/adminservice/domain/dto/SiteConfigResponseDto.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/domain/dto/SiteConfigResponseDto.java
@@ -5,7 +5,8 @@ import lombok.*;
 @Getter
 @Setter
 @NoArgsConstructor
-public class RequestAdminDto {
+@AllArgsConstructor
+public class SiteConfigResponseDto {
 
     private String jsVersion;
     private String cssVersion;

--- a/admin-service/src/main/java/com/wesell/adminservice/domain/dto/UserListResponseDto.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/domain/dto/UserListResponseDto.java
@@ -6,9 +6,10 @@ import lombok.*;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class ResponseAdminDto {
+@Builder
+public class UserListResponseDto {
 
-    private String jsVersion;
-    private String cssVersion;
-    private String title;
+    private Long id;
+    private String name;
+    private String nickname;
 }

--- a/admin-service/src/main/java/com/wesell/adminservice/feignClient/UserFeignClient.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/feignClient/UserFeignClient.java
@@ -1,0 +1,12 @@
+package com.wesell.adminservice.feignClient;
+
+import com.wesell.adminservice.domain.dto.UserListResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(name="USER-SERVICE", path = "user-service")
+public interface UserFeignClient {
+
+    @GetMapping("user-list")
+    UserListResponseDto getUserList();
+}


### PR DESCRIPTION
### dto 이름수정
- code convention 참고하여 dto 이름 수정
- requestAdminDto -> siteConfigRequestDto 
### getUserList (컨트롤러) 
- User서버의 목록을 feign이용해서 받아옴
### userListResponseDto
- id, nickname, name 값 설정
### getUserList (서비스)
- feign으로 받아온 값들을 Responsedto로 변환하는 로직
### UserFeignClient
- feign으로 user-service에서 회원 목록을 가져옴<br><br> ### user-service에서 user-service/user-list 엔드포인트로 responseDto에 해당하는 값을 넘겨주는 로직 구현 필요!!!