### PR TITLE
feat: 회원 목록 조회 구현

### DIFF
--- a/user-service/src/main/java/com/wesell/userservice/controller/UserController.java
+++ b/user-service/src/main/java/com/wesell/userservice/controller/UserController.java
@@ -1,0 +1,40 @@
+package com.wesell.userservice.controller;
+
+import com.wesell.userservice.dto.responseDto;
+import com.wesell.userservice.exception.UserNotFoundException;
+import com.wesell.userservice.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("user")
+    public ResponseEntity<responseDto> findUserResponseEntity(@RequestParam("uuid") String uuid) {
+
+        try {
+            return ResponseEntity.ok(userService.findUser(uuid));
+        } catch (UserNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+    }
+
+    @GetMapping("users")
+    public ResponseEntity<List<responseDto>> findUsersResponseEntity() {
+
+        try {
+            return ResponseEntity.ok(userService.findUsers());
+        } catch (UserNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+    }
+}

--- a/user-service/src/main/java/com/wesell/userservice/domain/entity/User.java
+++ b/user-service/src/main/java/com/wesell/userservice/domain/entity/User.java
@@ -47,4 +47,5 @@ public class User {
     @Column(name = "u_uuid", nullable = false)
     private String uuid;
 
+
 }

--- a/user-service/src/main/java/com/wesell/userservice/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/wesell/userservice/domain/repository/UserRepository.java
@@ -13,7 +13,7 @@ public class UserRepository {
     private final EntityManager em;
 
     public void save(User user) {   // 유저 정보 저장
-        if(user.getId() == null) {
+        if(user.getUuid() == null) {
             em.persist(user);   // 새로운 유저 정보 저장
         } else {
             em.merge(user);     // 이미 존재하는 유저 정보이므로 업데이트
@@ -24,11 +24,15 @@ public class UserRepository {
         em.remove(user);
     }
 
-    public User findByOneId(Long id) {  // 유저 id로 유저 한명 조회
-            return em.createQuery("select u from User u where u.id = :id", User.class)
-                    .setParameter("id", id)
+    public User findByOneId(String uuid) {  // 유저 id로 유저 한명 조회
+        try {
+            return em.createQuery("select u from User u where u.uuid = :uuid", User.class)
+                    .setParameter("uuid", uuid)
                     .getSingleResult();
+        } catch (Exception e) {
+            return null;
         }
+    }
 
     public List<User> findAll() {   // 유저 정보 전체 조회
         return em.createQuery("select u from User u", User.class)

--- a/user-service/src/main/java/com/wesell/userservice/dto/responseDto.java
+++ b/user-service/src/main/java/com/wesell/userservice/dto/responseDto.java
@@ -1,0 +1,45 @@
+package com.wesell.userservice.dto;
+
+import com.wesell.userservice.domain.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+public class responseDto {
+
+    private Long id;
+    private String name;
+    private String nickname;
+    private String phone;
+    private String uuid;
+
+
+    public static responseDto of(User user) {
+        return new responseDto(
+                user.getId(),
+                user.getName(),
+                user.getNickname(),
+                user.getPhone(),
+                user.getUuid()
+        );
+    }
+
+    public static List<responseDto> of(List<User> userList) {
+        return userList.stream()
+                .map(user -> new responseDto(
+                        user.getId(),
+                        user.getName(),
+                        user.getNickname(),
+                        user.getPhone(),
+                        user.getUuid()
+                ))
+                .collect(Collectors.toList());
+    }
+
+
+
+}

--- a/user-service/src/main/java/com/wesell/userservice/exception/UserNotFoundException.java
+++ b/user-service/src/main/java/com/wesell/userservice/exception/UserNotFoundException.java
@@ -1,0 +1,8 @@
+package com.wesell.userservice.exception;
+
+public class UserNotFoundException extends Exception {
+
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/user-service/src/main/java/com/wesell/userservice/service/UserService.java
+++ b/user-service/src/main/java/com/wesell/userservice/service/UserService.java
@@ -1,0 +1,33 @@
+package com.wesell.userservice.service;
+
+import com.wesell.userservice.dto.responseDto;
+import com.wesell.userservice.exception.UserNotFoundException;
+import com.wesell.userservice.domain.entity.User;
+import com.wesell.userservice.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public responseDto findUser(String uuid) throws UserNotFoundException { // uuid로 유저 조회
+        Optional<User> userOptional = Optional.ofNullable(userRepository.findByOneId(uuid));
+        User user = userOptional.orElseThrow(() ->
+                new UserNotFoundException("유저 정보를 찾을 수 없습니다."));
+        return responseDto.of(user);
+    }
+
+    public List<responseDto> findUsers() throws UserNotFoundException {
+        Optional<List<User>> usersOptional = Optional.ofNullable(userRepository.findAll());
+        List<User> userList = usersOptional.orElseThrow(() ->
+                new UserNotFoundException("유저 정보를 찾을 수 없습니다."));
+        return responseDto.of(userList);
+    }
+
+
+}

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 0
+  port: 8080
 
 spring:
   application:
@@ -20,11 +20,11 @@ spring:
         check_nullability: true
     show_sql: true
 
-  profiles:
+spring.profiles:
     active: db
 
 springdoc:
-  packages-to-scan: com.test.swaggertest.controllers
+  packages-to-scan: com.wesell.userservice.contoller
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
   swagger-ui:

--- a/user-service/src/test/java/com/wesell/userservice/domain/repository/UserRepositoryTest.java
+++ b/user-service/src/test/java/com/wesell/userservice/domain/repository/UserRepositoryTest.java
@@ -6,10 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
 import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
@@ -34,7 +31,7 @@ class UserRepositoryTest {
         userRepository.save(user);
 
         // 저장된 유저 정보 확인
-        User savedUser = userRepository.findByOneId(user.getId());
+        User savedUser = userRepository.findByOneId(user.getUuid());
         assertNotNull(savedUser);
         assertEquals("Beong ho", savedUser.getName());
         assertEquals("PBH", savedUser.getNickname());
@@ -58,14 +55,14 @@ class UserRepositoryTest {
         userRepository.save(user);
 
         // 저장된 유저 정보 확인
-        User savedUser = userRepository.findByOneId(user.getId());
+        User savedUser = userRepository.findByOneId(user.getUuid());
         assertNotNull(savedUser);
 
         // 저장된 유저 정보 삭제
         userRepository.delete(savedUser);
 
         // 삭제된 유저 정보 확인
-        User deletedUser = userRepository.findByOneId(savedUser.getId());
+        User deletedUser = userRepository.findByOneId(savedUser.getUuid());
         assertNull(deletedUser);
 
     }


### PR DESCRIPTION
* 회원 목록 조회 기능 구현

- 회원 uuid로 유저 정보 조회 기능 완료(postman으로 요청보냈을 때 문제X)
- 전체 회원 정보 조회 기능 완료(postman으로 요청보냈을 때 문제X)
- 민감정보처리 후 테스트 코드 에러와 데이터가 db에 반영 안되는 문제 해결
- null 값인 경우 에러 처리 완료, 회원 정보 기능 모두 구현되었을 때 따로 Exception 패키지에서 @ControllerAdvice로 에러 관련 메서드 정의해서 화면 출력할 예정임
- 이외에 수정사항이나 추가할사항있으면 자유롭게 댓글 바랍니다.