### PR TITLE
feat: JWT 쿠키 생성 및 전달 기능 구현

### DIFF
--- a/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AuthController.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AuthController.java
@@ -1,14 +1,18 @@
 package com.wesell.authenticationserver.controller;
 
-import com.wesell.authenticationserver.domain.entity.AuthUser;
 import com.wesell.authenticationserver.dto.GeneratedTokenDto;
+import com.wesell.authenticationserver.dto.LoginSuccessDto;
 import com.wesell.authenticationserver.dto.request.CreateUserRequestDto;
 import com.wesell.authenticationserver.dto.request.LoginUserRequestDto;
+import com.wesell.authenticationserver.global.util.CustomCookie;
+import com.wesell.authenticationserver.response.SuccessCode;
 import com.wesell.authenticationserver.service.AuthUserService;
 import com.wesell.authenticationserver.service.token.TokenProvider;
 import jakarta.validation.Valid;
+import jakarta.ws.rs.core.HttpHeaders;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,36 +27,60 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthUserService authUserService;
+    private final CustomCookie cookieProvider;
     private final TokenProvider tokenProvider;
 
+    // 헬스 체크
     @GetMapping("health-check")
     public ResponseEntity<String> healthCheck(){
         return ResponseEntity.ok().body("auth-server available");
     }
 
+    // 회원가입
     @PostMapping("sign-up")
-    public ResponseEntity<Void> signUp(@Valid @RequestBody CreateUserRequestDto dto){
+    public ResponseEntity<Void> signUp(@Valid @RequestBody CreateUserRequestDto requestDto){
 
         log.debug("AuthController - 회원가입");
 
-        authUserService.createUser(dto);
+        authUserService.createUser(requestDto);
 
-        return ResponseEntity.status(201).body(null);
+        return ResponseEntity
+                .status(SuccessCode.USER_CREATED.getStatus())
+                .body(null);
+    }
+
+    // 로그인
+    @PostMapping("login")
+    public ResponseEntity<Void> login(@Valid @RequestBody LoginUserRequestDto requestDto){
+
+        log.debug("AuthController - 로그인");
+
+        LoginSuccessDto loginSuccessDto = authUserService.login(requestDto);
+        
+        log.debug("AuthController - 쿠키 담기");
+        String accessToken = loginSuccessDto.getGeneratedTokenDto().getAccessToken();
+
+        ResponseCookie cookie = cookieProvider.createTokenCookie(accessToken);
+
+        return ResponseEntity
+                .status(SuccessCode.OK.getStatus())
+                .header(HttpHeaders.SET_COOKIE,cookie.toString())
+                .body(null);
     }
 
     /*===================================== TEST ======================================*/
-    @PostMapping("token-test")
-    public ResponseEntity<GeneratedTokenDto> createTokenTest(@RequestBody LoginUserRequestDto dto){
-        log.debug("Test - 로그인 상황 성공");
-
-        String email = dto.getEmail();
-
-        AuthUser user = authUserService.getOneByEmail(email);
-
-        GeneratedTokenDto generatedTokenDto = tokenProvider.generateToken(user);
-
-
-
-        return ResponseEntity.ok().body(generatedTokenDto);
-    }
+//    @PostMapping("token-test")
+//    public ResponseEntity<GeneratedTokenDto> createTokenTest(@RequestBody LoginUserRequestDto dto){
+//        log.debug("Test - 로그인 상황 성공");
+//
+//        String email = dto.getEmail();
+//
+//        AuthUser user = authUserService.getOneByEmail(email);
+//
+//        GeneratedTokenDto generatedTokenDto = tokenProvider.generateToken(user);
+//
+//
+//
+//        return ResponseEntity.ok().body(generatedTokenDto);
+//    }
 }

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/dto/LoginSuccessDto.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/dto/LoginSuccessDto.java
@@ -1,0 +1,13 @@
+package com.wesell.authenticationserver.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class LoginSuccessDto {
+
+    private GeneratedTokenDto generatedTokenDto;
+}

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/CustomCookie.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/CustomCookie.java
@@ -1,11 +1,43 @@
 package com.wesell.authenticationserver.global.util;
 
+import jakarta.servlet.http.Cookie;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
+import java.util.Optional;
+
+//JWT를 담을 쿠키 생성 및 기한 만료 기능 구현
 @Component
 public class CustomCookie {
 
+    // 쿠키 생성
+    public ResponseCookie createTokenCookie(String token){
 
+        return ResponseCookie.from("access-token", token)
+                .path("/")
+                .httpOnly(true)
+                .maxAge(60*60)
+                .build();
+    }
 
+    // 쿠키 무효화
+    public ResponseCookie deleteTokenCookie(){
+        return ResponseCookie.from("access-token")
+                .path("/")
+                .httpOnly(true)
+                .maxAge(0)
+                .build();
+    }
+
+    // 토큰 조회
+    public String getJwt(Cookie[] cookies){
+
+        Optional<Cookie> cookie = Arrays.stream(cookies)
+                .filter(c -> "access-token".equals(c.getName())).findFirst();
+
+        return cookie.orElseThrow(() -> new RuntimeException("권한이 없는 접근입니다.")).getValue();
+
+    }
 
 }

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/CustomPasswordEncoder.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/CustomPasswordEncoder.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class CustomPasswordEncoder {
     
-    private BCryptPasswordEncoder encoder;
+    private final BCryptPasswordEncoder encoder;
 
     public String encode(String pw){
         return encoder.encode(pw);

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/response/ErrorCode.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/response/ErrorCode.java
@@ -1,4 +1,4 @@
-package com.wesell.authenticationserver.error;
+package com.wesell.authenticationserver.response;
 
 import lombok.Getter;
 

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/response/ErrorControllerAdvisor.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/response/ErrorControllerAdvisor.java
@@ -1,4 +1,4 @@
-package com.wesell.authenticationserver.error;
+package com.wesell.authenticationserver.response;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/response/ErrorResponseDto.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/response/ErrorResponseDto.java
@@ -1,4 +1,4 @@
-package com.wesell.authenticationserver.error;
+package com.wesell.authenticationserver.response;
 
 import lombok.*;
 

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/response/SuccessCode.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/response/SuccessCode.java
@@ -1,0 +1,15 @@
+package com.wesell.authenticationserver.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SuccessCode {
+
+    OK(200),
+    USER_CREATED(201);
+
+    private final int status; // 상태코드(숫자)
+
+}

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/service/token/TokenProvider.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/service/token/TokenProvider.java
@@ -17,7 +17,6 @@ public class TokenProvider {
 
     private final RefreshTokenProvider refreshTokenProvider;
     private final AccessTokenProvider accessTokenProvider;
-    private final TokenInfoService tokenInfoService;
     private final TokenProperties tokenProperties;
 
     /**


### PR DESCRIPTION
🎇 feat: 쿠키 생성 기능 구현
- 쿠키 생성, 무효화, 내부 토큰 조회 기능 구현.

🎇 feat: 로그인 기능 및 쿠키 전달 구현
- 로그인 기본 기능 구현(유효성 검사 로직 추가 필요) -> play-62에서 구현 예정
- Swagger 테스트 결과, 정상 응답되며 브라우저 쿠키에 저장된것 확인함.

🎇 feat: 응답 성공 상태 코드 커스텀
- 응답 상태 코드 커스텀 구현 -> enum 사용

🎇 비밀번호 암호화 수정
- 비밀번호 암호화 관련 빈 객체 null 오류 발생하여, 확인해보니, 'final' 누락.
- 다음부터는 코드 확인 꼼꼼히 할 것!
