### PR TITLE
feat: 회원 로그인 기능 구현

### DIFF
--- a/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AuthController.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AuthController.java
@@ -20,6 +20,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Optional;
+
 @RestController
 @RequiredArgsConstructor
 @Log4j2
@@ -60,11 +62,24 @@ public class AuthController {
         log.debug("AuthController - 쿠키 담기");
         String accessToken = loginSuccessDto.getGeneratedTokenDto().getAccessToken();
 
-        ResponseCookie cookie = cookieProvider.createTokenCookie(accessToken);
+        ResponseCookie accessTokenCookie = cookieProvider.createTokenCookie(accessToken);
+
+        ResponseCookie savedEmailCookie;
+
+        if(requestDto.isSavedEmail()) {
+
+            savedEmailCookie = cookieProvider.createTokenCookie(requestDto.getEmail());
+
+        }else{
+
+            savedEmailCookie = cookieProvider.deleteSavedEmailCookie();
+
+        }
 
         return ResponseEntity
                 .status(SuccessCode.OK.getStatus())
-                .header(HttpHeaders.SET_COOKIE,cookie.toString())
+                .header(HttpHeaders.SET_COOKIE,accessTokenCookie.toString())
+                .header(HttpHeaders.SET_COOKIE,savedEmailCookie.toString())
                 .body(null);
     }
 

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/dto/request/LoginUserRequestDto.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/dto/request/LoginUserRequestDto.java
@@ -1,5 +1,6 @@
 package com.wesell.authenticationserver.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 @Getter
@@ -10,8 +11,9 @@ import lombok.*;
 @ToString
 public class LoginUserRequestDto {
 
+    @NotBlank(message="이메일을 입력해주세요")
     private String email;
 
+    @NotBlank(message="비밀번호를 입력해주세요.")
     private String password;
-
 }

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/dto/request/LoginUserRequestDto.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/dto/request/LoginUserRequestDto.java
@@ -16,4 +16,6 @@ public class LoginUserRequestDto {
 
     @NotBlank(message="비밀번호를 입력해주세요.")
     private String password;
+
+    private boolean savedEmail;
 }

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/CustomCookie.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/CustomCookie.java
@@ -21,6 +21,10 @@ public class CustomCookie {
                 .build();
     }
 
+    public ResponseCookie createSaveEmailCookie(String email){
+
+    }
+
     // 쿠키 무효화
     public ResponseCookie deleteTokenCookie(){
         return ResponseCookie.from("access-token")

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/CustomCookie.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/CustomCookie.java
@@ -21,13 +21,28 @@ public class CustomCookie {
                 .build();
     }
 
-    public ResponseCookie createSaveEmailCookie(String email){
+    // 로그인 시 이메일 저장 기능 쿠키 생성.
+    public ResponseCookie createSavedEmailCookie(String email){
+
+        return ResponseCookie.from("savedEmail",email)
+                .path("/")
+                .httpOnly(true)
+                .maxAge(60 * 60 *24)
+                .build();
 
     }
 
     // 쿠키 무효화
     public ResponseCookie deleteTokenCookie(){
         return ResponseCookie.from("access-token")
+                .path("/")
+                .httpOnly(true)
+                .maxAge(0)
+                .build();
+    }
+
+    public ResponseCookie deleteSavedEmailCookie(){
+        return ResponseCookie.from("savedEmail")
                 .path("/")
                 .httpOnly(true)
                 .maxAge(0)


### PR DESCRIPTION
🎆 feat: Login 시 입력값 null 여부 확인
- spring bean validation `@NotBalnk` 사용하여 null 여부 확인 및 null 시 에러 메시지 발생하도록 구현했습니다.

🎆 feat: 이메일 저장 기능 구현
- 이메일 저장 체크박스 체크 시, cookie에 담아서 해당 이메일을 클라이언트 서버로 전달해줍니다.
- 추후 프론트 서버측에서 해당 cookie를 조회 및 null 여부 확인하여 프론트 구현할 예정입니다.

❗실제 로그인 기능 구현은 [feat: JWT 쿠키 생성 및 전달 기능 구현](https://github.com/playdata-final-project-team/Wesell/pull/28) 에 되어 있으니 참고 바랍니다.