### PR TITLE
fix: AuthUserEntity 권한 변경 메서드 정의

### DIFF
--- a/authentication-server/src/main/java/com/wesell/authenticationserver/domain/entity/AuthUser.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/domain/entity/AuthUser.java
@@ -28,4 +28,12 @@ public class AuthUser {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;
+
+    private boolean isDelete; // 삭제 여부
+
+    private boolean isForced; // 강제 탈퇴 여부
+
+    public void changeRole(Role role){
+        this.role = role;
+    }
 }


### PR DESCRIPTION
❗권한 변경 로직 추가
- 권한 변경 기능 구현을 위해 Entitiy 내부에 role 필드만 수정할 수 있도록 메서드 정의함.