### PR TITLE
feat: 프론트에 전송할 responseDto 구현

### DIFF
--- a/deal-service/src/main/java/com/wesell/dealservice/controller/CategoryController.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/controller/CategoryController.java
@@ -1,7 +1,7 @@
 package com.wesell.dealservice.controller;
 
 import com.wesell.dealservice.dto.request.CreateCategoryRequestDto;
-import com.wesell.dealservice.service.CategoryService;
+import com.wesell.dealservice.service.CategoryServiceImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -11,14 +11,14 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("deal-service")
-@CrossOrigin("http://127.0.0.1:5500")
+//@CrossOrigin("http://127.0.0.1:5500")
 public class CategoryController {
 
-    private final CategoryService categoryService;
+    private final CategoryServiceImpl categoryServiceImpl;
 
     @PostMapping("category")
     public ResponseEntity<?> createDealPost(@Valid @RequestBody CreateCategoryRequestDto requestDto) {
-        categoryService.createCategory(requestDto);
+        categoryServiceImpl.createCategory(requestDto);
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
 

--- a/deal-service/src/main/java/com/wesell/dealservice/controller/CategoryController.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/controller/CategoryController.java
@@ -10,13 +10,13 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("category")
+@RequestMapping("deal-service")
 @CrossOrigin("http://127.0.0.1:5500")
 public class CategoryController {
 
     private final CategoryService categoryService;
 
-    @PostMapping("post")
+    @PostMapping("category")
     public ResponseEntity<?> createDealPost(@Valid @RequestBody CreateCategoryRequestDto requestDto) {
         categoryService.createCategory(requestDto);
         return new ResponseEntity<>(HttpStatus.CREATED);

--- a/deal-service/src/main/java/com/wesell/dealservice/controller/DealController.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/controller/DealController.java
@@ -11,8 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("deal")
-@CrossOrigin("http://127.0.0.1:5500")
+@RequestMapping("deal-service")
 public class DealController {
 
     private final DealServiceImpl dealService;
@@ -37,6 +36,11 @@ public class DealController {
     public ResponseEntity<?> deletePost(@Valid @RequestParam("id") Long postId) {
         dealService.deletePost(postId);
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @GetMapping("list")
+    public ResponseEntity<?> getMyPostInfo(@RequestParam("uuid") String uuid) {
+        return new ResponseEntity<>(dealService.getMyPostList(uuid),HttpStatus.OK);
     }
 
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/controller/DealController.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/controller/DealController.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,6 +34,12 @@ public class DealController {
     @PutMapping("edit")
     public ResponseEntity<?> editPost(@Valid @RequestBody EditPostRequestDto requestDto, @RequestParam("id") Long postId) {
         return new ResponseEntity<>(dealService.editPost(requestDto, postId),HttpStatus.OK);
+    }
+
+    @PutMapping("complete")
+    public ResponseEntity<?> changePostStatus(@Valid @RequestParam("id") Long postId) {
+        dealService.changePostStatus(postId);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 
     @DeleteMapping("delete")

--- a/deal-service/src/main/java/com/wesell/dealservice/controller/DealController.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/controller/DealController.java
@@ -2,6 +2,7 @@ package com.wesell.dealservice.controller;
 
 import com.wesell.dealservice.dto.request.CreateDealPostRequestDto;
 import com.wesell.dealservice.dto.request.EditPostRequestDto;
+import com.wesell.dealservice.service.CategoryServiceImpl;
 import com.wesell.dealservice.service.DealServiceImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -9,12 +10,16 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("deal-service")
 public class DealController {
 
     private final DealServiceImpl dealService;
+    private final CategoryServiceImpl categoryService;
 
     @PostMapping("post")
     public ResponseEntity<?> createDealPost(@Valid @RequestBody CreateDealPostRequestDto registerDto) {
@@ -41,6 +46,15 @@ public class DealController {
     @GetMapping("list")
     public ResponseEntity<?> getMyPostInfo(@RequestParam("uuid") String uuid) {
         return new ResponseEntity<>(dealService.getMyPostList(uuid),HttpStatus.OK);
+    }
+
+    @GetMapping("main")
+    public ResponseEntity<?> getMainInfo() {
+        Map<String, Object> mainInfo = new HashMap<>();
+        mainInfo.put("categoryInfo", categoryService.getMainPageInfo());
+        mainInfo.put("dealInfo", dealService.getMainPageInfo());
+
+        return new ResponseEntity<>(mainInfo, HttpStatus.OK);
     }
 
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/domain/entity/Category.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/domain/entity/Category.java
@@ -22,9 +22,4 @@ public class Category {
     @Transient
     private List<DealPost> products = new ArrayList<>();
 
-    @Builder
-    public Category(String value) {
-        this.value = value;
-    }
-
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/domain/entity/DealPost.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/domain/entity/DealPost.java
@@ -66,4 +66,8 @@ public class DealPost {
         this.category = category;
     }
 
+    public void changeStatus() {
+        this.status = SaleStatus.COMPLETED;
+    }
+
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/domain/entity/DealPost.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/domain/entity/DealPost.java
@@ -6,7 +6,6 @@ import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDate;
 
-
 @Entity @Getter
 @Table(name = "post")
 @AllArgsConstructor

--- a/deal-service/src/main/java/com/wesell/dealservice/domain/repository/CategoryRepository.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/domain/repository/CategoryRepository.java
@@ -2,6 +2,8 @@ package com.wesell.dealservice.domain.repository;
 
 import com.wesell.dealservice.domain.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+    List<Category> findAll();
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/domain/repository/DealRepository.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/domain/repository/DealRepository.java
@@ -2,8 +2,10 @@ package com.wesell.dealservice.domain.repository;
 
 import com.wesell.dealservice.domain.entity.DealPost;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
 public interface DealRepository extends JpaRepository<DealPost, Long> {
     DealPost findDealPostByUuidAndId(String uuid, Long id);
     DealPost findDealPostById(Long id);
+    List<DealPost> findAllByUuid(String uuid);
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/domain/repository/DealRepository.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/domain/repository/DealRepository.java
@@ -1,5 +1,6 @@
 package com.wesell.dealservice.domain.repository;
 
+import com.wesell.dealservice.domain.SaleStatus;
 import com.wesell.dealservice.domain.entity.DealPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
@@ -8,4 +9,5 @@ public interface DealRepository extends JpaRepository<DealPost, Long> {
     DealPost findDealPostByUuidAndId(String uuid, Long id);
     DealPost findDealPostById(Long id);
     List<DealPost> findAllByUuid(String uuid);
+    List<DealPost> findAllByStatus(SaleStatus status);
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/dto/response/MainPageCategoryResponseDto.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/dto/response/MainPageCategoryResponseDto.java
@@ -1,0 +1,17 @@
+package com.wesell.dealservice.dto.response;
+
+import com.wesell.dealservice.domain.entity.Category;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MainPageCategoryResponseDto {
+    private String value;
+
+    public MainPageCategoryResponseDto(Category category) {
+        this.value = category.getValue();
+    }
+}

--- a/deal-service/src/main/java/com/wesell/dealservice/dto/response/MainPagePostResponseDto.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/dto/response/MainPagePostResponseDto.java
@@ -1,0 +1,21 @@
+package com.wesell.dealservice.dto.response;
+
+import com.wesell.dealservice.domain.entity.DealPost;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MainPagePostResponseDto {
+
+    private String title;
+    private Long price;
+
+    public MainPagePostResponseDto(DealPost post) {
+        this.title = post.getTitle();
+        this.price = post.getPrice();
+    }
+
+}

--- a/deal-service/src/main/java/com/wesell/dealservice/dto/response/MyPostListResponseDto.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/dto/response/MyPostListResponseDto.java
@@ -1,0 +1,24 @@
+package com.wesell.dealservice.dto.response;
+
+import com.wesell.dealservice.domain.SaleStatus;
+import com.wesell.dealservice.domain.entity.DealPost;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MyPostListResponseDto {
+    private String title;
+    private LocalDate createdAt;
+    private SaleStatus status;
+
+    public MyPostListResponseDto(DealPost post) {
+        this.title = post.getTitle();
+        this.createdAt = post.getCreatedAt();
+        this.status = post.getStatus();
+    }
+
+}

--- a/deal-service/src/main/java/com/wesell/dealservice/service/CategoryService.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/service/CategoryService.java
@@ -1,22 +1,12 @@
 package com.wesell.dealservice.service;
 
 import com.wesell.dealservice.dto.request.CreateCategoryRequestDto;
-import com.wesell.dealservice.domain.entity.Category;
-import com.wesell.dealservice.domain.repository.CategoryRepository;
-import jakarta.transaction.Transactional;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import com.wesell.dealservice.dto.response.MainPageCategoryResponseDto;
+import java.util.List;
 
-@Service
-@Transactional
-@RequiredArgsConstructor
-public class CategoryService {
+public interface CategoryService {
+    void createCategory(CreateCategoryRequestDto requestDto);
 
-    private final CategoryRepository categoryRepository;
-
-    public void createCategory(CreateCategoryRequestDto requestDto) {
-        Category category = requestDto.toEntity();
-        categoryRepository.save(category);
-    }
+    List<MainPageCategoryResponseDto> getMainPageInfo();
 
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/service/CategoryServiceImpl.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/service/CategoryServiceImpl.java
@@ -1,0 +1,32 @@
+package com.wesell.dealservice.service;
+
+import com.wesell.dealservice.dto.request.CreateCategoryRequestDto;
+import com.wesell.dealservice.domain.entity.Category;
+import com.wesell.dealservice.domain.repository.CategoryRepository;
+import com.wesell.dealservice.dto.response.MainPageCategoryResponseDto;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CategoryServiceImpl implements CategoryService{
+
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    public void createCategory(CreateCategoryRequestDto requestDto) {
+        Category category = requestDto.toEntity();
+        categoryRepository.save(category);
+    }
+
+    @Override
+    public List<MainPageCategoryResponseDto> getMainPageInfo() {
+        List<Category> categories = categoryRepository.findAll();
+        return categories.stream().map(MainPageCategoryResponseDto::new).collect(Collectors.toList());
+    }
+
+}

--- a/deal-service/src/main/java/com/wesell/dealservice/service/DealService.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/service/DealService.java
@@ -14,6 +14,6 @@ public interface DealService {
     void deletePost(Long postId);
     PostInfoResponseDto getPostInfo(Long postId);
     List<MyPostListResponseDto> getMyPostList(String uuid);
-
     List<MainPagePostResponseDto> getMainPageInfo();
+    void changePostStatus(Long id);
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/service/DealService.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/service/DealService.java
@@ -3,11 +3,14 @@ package com.wesell.dealservice.service;
 import com.wesell.dealservice.dto.request.CreateDealPostRequestDto;
 import com.wesell.dealservice.dto.request.EditPostRequestDto;
 import com.wesell.dealservice.dto.response.EditPostResponseDto;
+import com.wesell.dealservice.dto.response.MyPostListResponseDto;
 import com.wesell.dealservice.dto.response.PostInfoResponseDto;
+import java.util.List;
 
 public interface DealService {
     void createDealPost(CreateDealPostRequestDto requestCreatePostDto);
     EditPostResponseDto editPost(EditPostRequestDto requestDto, Long postId);
     void deletePost(Long postId);
     PostInfoResponseDto getPostInfo(Long postId);
+    List<MyPostListResponseDto> getMyPostList(String uuid);
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/service/DealService.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/service/DealService.java
@@ -3,6 +3,7 @@ package com.wesell.dealservice.service;
 import com.wesell.dealservice.dto.request.CreateDealPostRequestDto;
 import com.wesell.dealservice.dto.request.EditPostRequestDto;
 import com.wesell.dealservice.dto.response.EditPostResponseDto;
+import com.wesell.dealservice.dto.response.MainPagePostResponseDto;
 import com.wesell.dealservice.dto.response.MyPostListResponseDto;
 import com.wesell.dealservice.dto.response.PostInfoResponseDto;
 import java.util.List;
@@ -13,4 +14,6 @@ public interface DealService {
     void deletePost(Long postId);
     PostInfoResponseDto getPostInfo(Long postId);
     List<MyPostListResponseDto> getMyPostList(String uuid);
+
+    List<MainPagePostResponseDto> getMainPageInfo();
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/service/DealServiceImpl.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/service/DealServiceImpl.java
@@ -1,8 +1,10 @@
 package com.wesell.dealservice.service;
 
+import com.wesell.dealservice.domain.SaleStatus;
 import com.wesell.dealservice.dto.request.CreateDealPostRequestDto;
 import com.wesell.dealservice.dto.request.EditPostRequestDto;
 import com.wesell.dealservice.dto.response.EditPostResponseDto;
+import com.wesell.dealservice.dto.response.MainPagePostResponseDto;
 import com.wesell.dealservice.dto.response.MyPostListResponseDto;
 import com.wesell.dealservice.dto.response.PostInfoResponseDto;
 import com.wesell.dealservice.domain.entity.Category;
@@ -72,6 +74,12 @@ public class DealServiceImpl implements DealService {
     public List<MyPostListResponseDto> getMyPostList(String uuid) {
         List<DealPost> allByUuid = dealRepository.findAllByUuid(uuid);
         return allByUuid.stream().map(MyPostListResponseDto::new).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<MainPagePostResponseDto> getMainPageInfo() {
+        List<DealPost> dealPosts = dealRepository.findAllByStatus(SaleStatus.IN_PROGRESS);
+        return dealPosts.stream().map(MainPagePostResponseDto::new).collect(Collectors.toList());
     }
 
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/service/DealServiceImpl.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/service/DealServiceImpl.java
@@ -3,6 +3,7 @@ package com.wesell.dealservice.service;
 import com.wesell.dealservice.dto.request.CreateDealPostRequestDto;
 import com.wesell.dealservice.dto.request.EditPostRequestDto;
 import com.wesell.dealservice.dto.response.EditPostResponseDto;
+import com.wesell.dealservice.dto.response.MyPostListResponseDto;
 import com.wesell.dealservice.dto.response.PostInfoResponseDto;
 import com.wesell.dealservice.domain.entity.Category;
 import com.wesell.dealservice.domain.entity.DealPost;
@@ -13,6 +14,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -62,6 +65,13 @@ public class DealServiceImpl implements DealService {
         DealPost foundPost = dealRepository.findDealPostById(postId);
         String nickname = userFeignClient.getNicknameByUuid(foundPost.getUuid());
         return new PostInfoResponseDto(foundPost, nickname);
+    }
+
+    // 판매 내역 리스트 정보
+    @Override
+    public List<MyPostListResponseDto> getMyPostList(String uuid) {
+        List<DealPost> allByUuid = dealRepository.findAllByUuid(uuid);
+        return allByUuid.stream().map(MyPostListResponseDto::new).collect(Collectors.toList());
     }
 
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/service/DealServiceImpl.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/service/DealServiceImpl.java
@@ -82,4 +82,10 @@ public class DealServiceImpl implements DealService {
         return dealPosts.stream().map(MainPagePostResponseDto::new).collect(Collectors.toList());
     }
 
+    @Override
+    public void changePostStatus(Long id) {
+        DealPost post = dealRepository.findDealPostById(id);
+        post.changeStatus();
+    }
+
 }


### PR DESCRIPTION
1. 마이페이지 2의 판매리스트 (제목, 생성 날짜, 판매 상태)의 정보를 담은 dto와 컨트롤러 생성했습니다.

2. 메인페이지의 카테고리 리스트, 상품 리스트(제목, 가격)의 정보를 담은 dto와 컨트롤러 생성했습니다.

3. 메인페이지에 보이는 상품리스트는 SaleStatus 값이 in_progress인 경우만 보여줍니다. 스프린트에는 없지만, 이를 확인하기 위해 게시글 판매 완료로 상태 변경하는 기능을 추가하여 구현했습니다. 테스트 결과 상태 변경값도 db에 잘 저장되었고, 메인페이지에도 잘 걸러 나오는 것을 확인했습니다!
