### PR TITLE
fix: 회원 목록 조회 기능 수정

### DIFF
--- a/admin-service/src/main/java/com/wesell/adminservice/AdminServiceApplication.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/AdminServiceApplication.java
@@ -3,11 +3,11 @@ package com.wesell.adminservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
-import org.springframework.context.annotation.ComponentScan;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
 @EnableDiscoveryClient
-@ComponentScan("com.wesell.adminservice.feignClient")
+@EnableFeignClients(basePackages = "com.wesell.adminservice.feignClient")
 public class AdminServiceApplication {
 
 	public static void main(String[] args) {

--- a/admin-service/src/main/java/com/wesell/adminservice/controller/AdminController.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/controller/AdminController.java
@@ -1,19 +1,18 @@
 package com.wesell.adminservice.controller;
 
-import com.wesell.adminservice.domain.dto.SiteConfigRequestDto;
-import com.wesell.adminservice.domain.dto.SiteConfigResponseDto;
-import com.wesell.adminservice.domain.dto.UserListResponseDto;
+import com.wesell.adminservice.domain.dto.request.SiteConfigRequestDto;
+import com.wesell.adminservice.domain.dto.response.SiteConfigResponseDto;
+import com.wesell.adminservice.domain.dto.response.UserListResponseDto;
 import com.wesell.adminservice.service.AdminService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @RestController
-@RequestMapping("admin")
 @RequiredArgsConstructor
 public class AdminController {
 
@@ -31,10 +30,9 @@ public class AdminController {
         return new ResponseEntity<>(currentSiteConfig, HttpStatus.OK);
     }
 
-    @GetMapping("get/user-list")
-    public ResponseEntity<UserListResponseDto> getUserList() {
-        UserListResponseDto userListResponseDto = adminService.getUserList();
-        return new ResponseEntity<>(userListResponseDto, HttpStatus.OK);
+    @GetMapping("get/users")
+    public ResponseEntity<List<UserListResponseDto>> getUserList() {
+        return adminService.getUserList();
     }
 
     @GetMapping("version")

--- a/admin-service/src/main/java/com/wesell/adminservice/domain/dto/request/SiteConfigRequestDto.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/domain/dto/request/SiteConfigRequestDto.java
@@ -1,12 +1,11 @@
-package com.wesell.adminservice.domain.dto;
+package com.wesell.adminservice.domain.dto.request;
 
 import lombok.*;
 
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
-public class SiteConfigResponseDto {
+public class SiteConfigRequestDto {
 
     private String jsVersion;
     private String cssVersion;

--- a/admin-service/src/main/java/com/wesell/adminservice/domain/dto/response/SiteConfigResponseDto.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/domain/dto/response/SiteConfigResponseDto.java
@@ -1,11 +1,12 @@
-package com.wesell.adminservice.domain.dto;
+package com.wesell.adminservice.domain.dto.response;
 
 import lombok.*;
 
 @Getter
 @Setter
 @NoArgsConstructor
-public class SiteConfigRequestDto {
+@AllArgsConstructor
+public class SiteConfigResponseDto {
 
     private String jsVersion;
     private String cssVersion;

--- a/admin-service/src/main/java/com/wesell/adminservice/domain/dto/response/UserListResponseDto.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/domain/dto/response/UserListResponseDto.java
@@ -1,4 +1,4 @@
-package com.wesell.adminservice.domain.dto;
+package com.wesell.adminservice.domain.dto.response;
 
 import lombok.*;
 

--- a/admin-service/src/main/java/com/wesell/adminservice/feignClient/UserFeignClient.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/feignClient/UserFeignClient.java
@@ -1,12 +1,14 @@
 package com.wesell.adminservice.feignClient;
 
-import com.wesell.adminservice.domain.dto.UserListResponseDto;
+import com.wesell.adminservice.domain.dto.response.UserListResponseDto;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import java.util.List;
 
-@FeignClient(name="USER-SERVICE", path = "user-service")
+@FeignClient(name="USER-SERVICE")
 public interface UserFeignClient {
 
-    @GetMapping("user-list")
-    UserListResponseDto getUserList();
+    @GetMapping("users")
+    ResponseEntity<List<UserListResponseDto>> getUserList();
 }

--- a/admin-service/src/main/java/com/wesell/adminservice/service/AdminService.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/service/AdminService.java
@@ -2,15 +2,17 @@ package com.wesell.adminservice.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.wesell.adminservice.domain.dto.UserListResponseDto;
+import com.wesell.adminservice.domain.dto.request.SiteConfigRequestDto;
+import com.wesell.adminservice.domain.dto.response.SiteConfigResponseDto;
+import com.wesell.adminservice.domain.dto.response.UserListResponseDto;
 import com.wesell.adminservice.domain.entity.SiteConfig;
-import com.wesell.adminservice.domain.dto.SiteConfigRequestDto;
-import com.wesell.adminservice.domain.dto.SiteConfigResponseDto;
 import com.wesell.adminservice.domain.repository.AdminRepository;
 import com.wesell.adminservice.feignClient.UserFeignClient;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -54,13 +56,8 @@ public class AdminService {
         return siteConfigOptional.map(this::siteConfigToResponseDto).orElse(new SiteConfigResponseDto());
     }
 
-    public UserListResponseDto getUserList(){
-        UserListResponseDto responseDto = userFeignClient.getUserList();
-        return UserListResponseDto.builder()
-                .id(responseDto.getId())
-                .name(responseDto.getName())
-                .nickname(responseDto.getNickname())
-                .build();
+    public ResponseEntity<List<UserListResponseDto>> getUserList(){
+        return userFeignClient.getUserList();
     }
 
         public SiteConfigRequestDto mapToRequestAdminDto(Map<String, String> versions) {


### PR DESCRIPTION
### dto패키지 하위에 request, response 하위 패키지 생성

### mainApplication에 @EnableFeign 추가
기존 코드에서 feign을 잡지 못해서 @ComponentScan을 이용해서 강제로 스캔했었는데
이 애너테이션 때문에 스캔 범위가 좁아져서 @EnableFeign으로 수정해서 해결했습니다.

### user-service에 기능이 완료됨에 따라 값을 받아오는 feign 로직 반환값 수정
