### PR TITLE
ref: 코드 리팩토링

### DIFF
--- a/deal-service/src/main/java/com/wesell/dealservice/controller/DealController.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/controller/DealController.java
@@ -56,8 +56,8 @@ public class DealController {
     @GetMapping("main")
     public ResponseEntity<?> getMainInfo() {
         Map<String, Object> mainInfo = new HashMap<>();
-        mainInfo.put("categoryInfo", categoryService.getMainPageInfo());
-        mainInfo.put("dealInfo", dealService.getMainPageInfo());
+        mainInfo.put("categoryInfo", categoryService.getCategoryList());
+        mainInfo.put("dealInfo", dealService.getDealPostLists());
 
         return new ResponseEntity<>(mainInfo, HttpStatus.OK);
     }

--- a/deal-service/src/main/java/com/wesell/dealservice/controller/DealController.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/controller/DealController.java
@@ -2,7 +2,7 @@ package com.wesell.dealservice.controller;
 
 import com.wesell.dealservice.dto.request.CreateDealPostRequestDto;
 import com.wesell.dealservice.dto.request.EditPostRequestDto;
-import com.wesell.dealservice.service.CategoryServiceImpl;
+import com.wesell.dealservice.facade.MainPageFacadeService;
 import com.wesell.dealservice.service.DealServiceImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +18,7 @@ import java.util.Map;
 public class DealController {
 
     private final DealServiceImpl dealService;
-    private final CategoryServiceImpl categoryService;
+    private final MainPageFacadeService facadeService;
 
     @PostMapping("post")
     public ResponseEntity<?> createDealPost(@Valid @RequestBody CreateDealPostRequestDto registerDto) {
@@ -55,11 +55,7 @@ public class DealController {
 
     @GetMapping("main")
     public ResponseEntity<?> getMainInfo() {
-        Map<String, Object> mainInfo = new HashMap<>();
-        mainInfo.put("categoryInfo", categoryService.getCategoryList());
-        mainInfo.put("dealInfo", dealService.getDealPostLists());
-
-        return new ResponseEntity<>(mainInfo, HttpStatus.OK);
+        return new ResponseEntity<>(facadeService.getFacadeDto(), HttpStatus.OK);
     }
 
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/controller/DealController.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/controller/DealController.java
@@ -61,7 +61,7 @@ public class DealController {
      * @param uuid & postId
      * @return 게시글 논리 삭제
      */
-    @DeleteMapping("delete")
+    @PutMapping("delete")
     public ResponseEntity<?> deletePost(@Valid @RequestParam("uuid") String uuid,  @RequestParam("id") Long postId) {
         dealService.deletePost(uuid, postId);
         return new ResponseEntity<>(HttpStatus.OK);

--- a/deal-service/src/main/java/com/wesell/dealservice/controller/DealController.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/controller/DealController.java
@@ -9,8 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import java.util.HashMap;
-import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,39 +18,67 @@ public class DealController {
     private final DealServiceImpl dealService;
     private final MainPageFacadeService facadeService;
 
+
+    /**
+     * @param requestDto 요청
+     * @return 게시글 저장
+     */
     @PostMapping("post")
-    public ResponseEntity<?> createDealPost(@Valid @RequestBody CreateDealPostRequestDto registerDto) {
-        dealService.createDealPost(registerDto);
+    public ResponseEntity<?> createDealPost(@Valid @RequestBody CreateDealPostRequestDto requestDto) {
+        dealService.createDealPost(requestDto);
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
 
+    /**
+     * @param postId 요청
+     * @return 상세글 보기 (제목, 생성날짜, 가격, 상세설명, 링크, 작성자 닉네임)
+     */
     @GetMapping("post")
     public ResponseEntity<?> getPostInfo(@Valid @RequestParam("id") Long postId) {
         return new ResponseEntity<>(dealService.getPostInfo(postId), HttpStatus.OK);
     }
 
+    /**
+     * @param requestDto & postId
+     * @return 게시글 수정
+     */
     @PutMapping("edit")
     public ResponseEntity<?> editPost(@Valid @RequestBody EditPostRequestDto requestDto, @RequestParam("id") Long postId) {
         return new ResponseEntity<>(dealService.editPost(requestDto, postId),HttpStatus.OK);
     }
 
+    /**
+     * @param uuid & postId
+     * @return 상태 변경(판매 완료)
+     */
     @PutMapping("complete")
     public ResponseEntity<?> changePostStatus(@Valid @RequestParam("uuid") String uuid, @RequestParam("id") Long postId) {
         dealService.changePostStatus(uuid, postId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    /**
+     * @param uuid & postId
+     * @return 게시글 논리 삭제
+     */
     @DeleteMapping("delete")
     public ResponseEntity<?> deletePost(@Valid @RequestParam("uuid") String uuid,  @RequestParam("id") Long postId) {
         dealService.deletePost(uuid, postId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    /**
+     * @param uuid
+     * @return 나의 판매 내역 (판매 완료, 판매 중) -> 삭제된 내역은 없음
+     */
     @GetMapping("list")
     public ResponseEntity<?> getMyPostInfo(@RequestParam("uuid") String uuid) {
         return new ResponseEntity<>(dealService.getMyPostList(uuid),HttpStatus.OK);
     }
 
+    /**
+     * @return 카테고리 리스트와 판매중인 게시글
+     */
     @GetMapping("main")
     public ResponseEntity<?> getMainInfo() {
         return new ResponseEntity<>(facadeService.getFacadeDto(), HttpStatus.OK);

--- a/deal-service/src/main/java/com/wesell/dealservice/controller/DealController.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/controller/DealController.java
@@ -37,14 +37,14 @@ public class DealController {
     }
 
     @PutMapping("complete")
-    public ResponseEntity<?> changePostStatus(@Valid @RequestParam("id") Long postId) {
-        dealService.changePostStatus(postId);
+    public ResponseEntity<?> changePostStatus(@Valid @RequestParam("uuid") String uuid, @RequestParam("id") Long postId) {
+        dealService.changePostStatus(uuid, postId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
     @DeleteMapping("delete")
-    public ResponseEntity<?> deletePost(@Valid @RequestParam("id") Long postId) {
-        dealService.deletePost(postId);
+    public ResponseEntity<?> deletePost(@Valid @RequestParam("uuid") String uuid,  @RequestParam("id") Long postId) {
+        dealService.deletePost(uuid, postId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 

--- a/deal-service/src/main/java/com/wesell/dealservice/domain/entity/DealPost.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/domain/entity/DealPost.java
@@ -42,9 +42,12 @@ public class DealPost {
     @Column(name = "p_createTime")
     LocalDate createdAt;
 
+    @Column(name = "isDeleted", nullable = false)
+    Boolean isDeleted;
+
     @Builder
     public DealPost(String uuid, Category category, String title, Long price,
-                    String link, String detail, LocalDate createdAt) {
+                    String link, String detail, LocalDate createdAt, Boolean isDeleted) {
         this.uuid = uuid;
         this.category = category;
         this.title = title;
@@ -53,6 +56,7 @@ public class DealPost {
         this.detail = detail;
         this.status = SaleStatus.IN_PROGRESS;
         this.createdAt = createdAt;
+        this.isDeleted = false;
     }
 
     public void editPost(EditPostRequestDto dto) {
@@ -68,6 +72,10 @@ public class DealPost {
 
     public void changeStatus() {
         this.status = SaleStatus.COMPLETED;
+    }
+
+    public void deleteMyPost() {
+        this.isDeleted = true;
     }
 
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/domain/repository/DealRepository.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/domain/repository/DealRepository.java
@@ -8,6 +8,7 @@ import java.util.List;
 public interface DealRepository extends JpaRepository<DealPost, Long> {
     DealPost findDealPostByUuidAndId(String uuid, Long id);
     DealPost findDealPostById(Long id);
+    DealPost findDealPostByUuid(String uuid);
     List<DealPost> findAllByUuid(String uuid);
     List<DealPost> findAllByStatus(SaleStatus status);
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/domain/repository/DealRepository.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/domain/repository/DealRepository.java
@@ -6,10 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface DealRepository extends JpaRepository<DealPost, Long> {
+    DealPost findFirstByUuid(String uuid);
     DealPost findDealPostByUuidAndId(String uuid, Long id);
-    DealPost findDealPostById(Long id);
     DealPost findDealPostByIdAndIsDeleted(Long id, Boolean isDeleted);
-    DealPost findDealPostByUuid(String uuid);
+    DealPost findDealPostByIdAndStatusAndIsDeleted(Long id, SaleStatus status, Boolean isDeleted);
     List<DealPost> findAllByUuidAndIsDeleted(String uuid, Boolean isDeleted);
     List<DealPost> findAllByStatusAndIsDeleted(SaleStatus status, Boolean isDeleted);
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/domain/repository/DealRepository.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/domain/repository/DealRepository.java
@@ -8,7 +8,8 @@ import java.util.List;
 public interface DealRepository extends JpaRepository<DealPost, Long> {
     DealPost findDealPostByUuidAndId(String uuid, Long id);
     DealPost findDealPostById(Long id);
+    DealPost findDealPostByIdAndIsDeleted(Long id, Boolean isDeleted);
     DealPost findDealPostByUuid(String uuid);
-    List<DealPost> findAllByUuid(String uuid);
-    List<DealPost> findAllByStatus(SaleStatus status);
+    List<DealPost> findAllByUuidAndIsDeleted(String uuid, Boolean isDeleted);
+    List<DealPost> findAllByStatusAndIsDeleted(SaleStatus status, Boolean isDeleted);
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/dto/FacadeDto.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/dto/FacadeDto.java
@@ -1,0 +1,16 @@
+package com.wesell.dealservice.dto;
+
+import com.wesell.dealservice.dto.response.MainPageCategoryResponseDto;
+import com.wesell.dealservice.dto.response.MainPagePostResponseDto;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter @Setter
+public class FacadeDto {
+
+    private List<MainPageCategoryResponseDto> categoryDto;
+    private List<MainPagePostResponseDto> postDto;
+
+}

--- a/deal-service/src/main/java/com/wesell/dealservice/dto/response/ErrorResponseDto.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/dto/response/ErrorResponseDto.java
@@ -1,26 +1,28 @@
 package com.wesell.dealservice.dto.response;
 
 import com.wesell.dealservice.error.exception.CustomException;
-import lombok.Getter;
+import lombok.*;
 import org.springframework.http.HttpStatus;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Getter
 public class ErrorResponseDto {
 
-    private final String timeStamp;
+    private final String timestamp;
     private final String trackingId;
     private final HttpStatus status;
     private final String code;
+    private final List<Object> message;
     private final String detailMessage;
 
-    public ErrorResponseDto(CustomException e) {
-        this.timeStamp = LocalDateTime.now().toString();
+    public ErrorResponseDto(CustomException e){
+        this.timestamp = LocalDateTime.now().toString();
         this.trackingId = UUID.randomUUID().toString();
         this.status = e.getErrorCode().getStatus();
         this.code = e.getClass().getSimpleName();
+        this.message = List.of(e.getErrorCode().getMessage());
         this.detailMessage = e.getMessage();
     }
-
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/error/ControllerAdvisor.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/error/ControllerAdvisor.java
@@ -11,10 +11,12 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class ControllerAdvisor {
 
-    @ExceptionHandler
-    protected ResponseEntity<ErrorResponseDto> customExceptionHandler(CustomException e) {
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<ErrorResponseDto> customExceptionHandler(CustomException e){
         ErrorResponseDto dto = new ErrorResponseDto(e);
         log.error("Error occurred in controller advice: [id={}]", dto.getTrackingId());
         return ResponseEntity.status(e.getErrorCode().getStatus()).body(dto);
     }
+
+
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/error/ErrorCode.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/error/ErrorCode.java
@@ -1,18 +1,23 @@
 package com.wesell.dealservice.error;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
 public enum ErrorCode {
+    /**
+     * create category
+     */
+    DUPLICATED_REQUEST(HttpStatus.BAD_REQUEST, "400", "이미 존재하는 카테고리입니다."),
 
     /**
      * create posting
      */
-    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "유효하지 않은 요청입니다.");
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "400", "유효하지 않은 요청입니다.");
 
     private final HttpStatus status;
+    private final String code;
     private final String message;
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/error/exception/CustomException.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/error/exception/CustomException.java
@@ -1,16 +1,14 @@
 package com.wesell.dealservice.error.exception;
 
 import com.wesell.dealservice.error.ErrorCode;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class CustomException extends RuntimeException{
     ErrorCode errorCode;
 
-    public CustomException(ErrorCode errorCode, String detailMessage) {
-        super(detailMessage);
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/facade/MainPageFacadeService.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/facade/MainPageFacadeService.java
@@ -1,0 +1,23 @@
+package com.wesell.dealservice.facade;
+
+import com.wesell.dealservice.dto.FacadeDto;
+import com.wesell.dealservice.service.CategoryServiceImpl;
+import com.wesell.dealservice.service.DealServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MainPageFacadeService {
+
+    private final CategoryServiceImpl categoryService;
+    private final DealServiceImpl dealService;
+
+    public FacadeDto getFacadeDto() {
+        FacadeDto dto = new FacadeDto();
+        dto.setCategoryDto(categoryService.getCategoryList());
+        dto.setPostDto(dealService.getDealPostLists());
+
+        return dto;
+    }
+}

--- a/deal-service/src/main/java/com/wesell/dealservice/service/CategoryService.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/service/CategoryService.java
@@ -6,7 +6,5 @@ import java.util.List;
 
 public interface CategoryService {
     void createCategory(CreateCategoryRequestDto requestDto);
-
-    List<MainPageCategoryResponseDto> getMainPageInfo();
-
+    List<MainPageCategoryResponseDto> getCategoryList();
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/service/CategoryServiceImpl.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/service/CategoryServiceImpl.java
@@ -4,6 +4,8 @@ import com.wesell.dealservice.dto.request.CreateCategoryRequestDto;
 import com.wesell.dealservice.domain.entity.Category;
 import com.wesell.dealservice.domain.repository.CategoryRepository;
 import com.wesell.dealservice.dto.response.MainPageCategoryResponseDto;
+import com.wesell.dealservice.error.ErrorCode;
+import com.wesell.dealservice.error.exception.CustomException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,6 +22,11 @@ public class CategoryServiceImpl implements CategoryService{
     //카테고리 생성
     @Override
     public void createCategory(CreateCategoryRequestDto requestDto) {
+
+        if(categoryRepository.findAll().contains(requestDto.getValue())) {
+            throw new CustomException(ErrorCode.DUPLICATED_REQUEST);
+        }
+
         Category category = requestDto.toEntity();
         categoryRepository.save(category);
     }

--- a/deal-service/src/main/java/com/wesell/dealservice/service/CategoryServiceImpl.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/service/CategoryServiceImpl.java
@@ -17,14 +17,16 @@ public class CategoryServiceImpl implements CategoryService{
 
     private final CategoryRepository categoryRepository;
 
+    //카테고리 생성
     @Override
     public void createCategory(CreateCategoryRequestDto requestDto) {
         Category category = requestDto.toEntity();
         categoryRepository.save(category);
     }
 
+    //카테고리 리스트
     @Override
-    public List<MainPageCategoryResponseDto> getMainPageInfo() {
+    public List<MainPageCategoryResponseDto> getCategoryList() {
         List<Category> categories = categoryRepository.findAll();
         return categories.stream().map(MainPageCategoryResponseDto::new).collect(Collectors.toList());
     }

--- a/deal-service/src/main/java/com/wesell/dealservice/service/DealService.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/service/DealService.java
@@ -14,6 +14,6 @@ public interface DealService {
     void deletePost(Long postId);
     PostInfoResponseDto getPostInfo(Long postId);
     List<MyPostListResponseDto> getMyPostList(String uuid);
-    List<MainPagePostResponseDto> getMainPageInfo();
+    List<MainPagePostResponseDto> getDealPostLists();
     void changePostStatus(Long id);
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/service/DealService.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/service/DealService.java
@@ -11,9 +11,9 @@ import java.util.List;
 public interface DealService {
     void createDealPost(CreateDealPostRequestDto requestCreatePostDto);
     EditPostResponseDto editPost(EditPostRequestDto requestDto, Long postId);
-    void deletePost(Long postId);
+    void deletePost(String uuid, Long postId);
     PostInfoResponseDto getPostInfo(Long postId);
     List<MyPostListResponseDto> getMyPostList(String uuid);
     List<MainPagePostResponseDto> getDealPostLists();
-    void changePostStatus(Long id);
+    void changePostStatus(String uuid, Long id);
 }

--- a/deal-service/src/main/java/com/wesell/dealservice/service/DealServiceImpl.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/service/DealServiceImpl.java
@@ -63,7 +63,7 @@ public class DealServiceImpl implements DealService {
 
     @Override
     public PostInfoResponseDto getPostInfo(Long postId) {
-        DealPost foundPost = dealRepository.findDealPostByIdAndIsDeleted(postId, false);
+        DealPost foundPost = dealRepository.findDealPostByIdAndStatusAndIsDeleted(postId, SaleStatus.IN_PROGRESS,  false);
         String nickname = userFeignClient.getNicknameByUuid(foundPost.getUuid());
         return new PostInfoResponseDto(foundPost, nickname);
     }
@@ -89,7 +89,7 @@ public class DealServiceImpl implements DealService {
     }
 
     public void checkValidationByUuid(String uuid) {
-        DealPost post = dealRepository.findDealPostByUuid(uuid);
+        DealPost post = dealRepository.findFirstByUuid(uuid);
         if(!uuid.equals(post.getUuid())) {
             throw new CustomException(ErrorCode.INVALID_REQUEST);
         }

--- a/deal-service/src/main/java/com/wesell/dealservice/service/DealServiceImpl.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/service/DealServiceImpl.java
@@ -77,7 +77,7 @@ public class DealServiceImpl implements DealService {
     }
 
     @Override
-    public List<MainPagePostResponseDto> getMainPageInfo() {
+    public List<MainPagePostResponseDto> getDealPostLists() {
         List<DealPost> dealPosts = dealRepository.findAllByStatus(SaleStatus.IN_PROGRESS);
         return dealPosts.stream().map(MainPagePostResponseDto::new).collect(Collectors.toList());
     }

--- a/deal-service/src/main/java/com/wesell/dealservice/service/DealServiceImpl.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/service/DealServiceImpl.java
@@ -27,7 +27,6 @@ public class DealServiceImpl implements DealService {
     private final CategoryRepository categoryRepository;
     private final UserFeignClient userFeignClient;
 
-    // 거래 글 생성
     @Override
     public void createDealPost(CreateDealPostRequestDto requestDto) {
         Category category = categoryRepository.findById(requestDto.getCategoryId()).get();
@@ -43,7 +42,6 @@ public class DealServiceImpl implements DealService {
         dealRepository.save(post);
     }
 
-    // 거래 글 수정
     @Override
     public EditPostResponseDto editPost(EditPostRequestDto requestDto, Long postId) {
         checkValidationByUuid(requestDto.getUuid());
@@ -56,39 +54,37 @@ public class DealServiceImpl implements DealService {
         return new EditPostResponseDto(editPost);
     }
 
-    // 거래 글 삭제
     @Override
     public void deletePost(String uuid, Long postId) {
         checkValidationByUuid(uuid);
-        dealRepository.deleteById(postId);
+        DealPost post = dealRepository.findDealPostByUuidAndId(uuid, postId);
+        post.deleteMyPost();
     }
 
-    //거래 글 상세 정보
     @Override
     public PostInfoResponseDto getPostInfo(Long postId) {
-        DealPost foundPost = dealRepository.findDealPostById(postId);
+        DealPost foundPost = dealRepository.findDealPostByIdAndIsDeleted(postId, false);
         String nickname = userFeignClient.getNicknameByUuid(foundPost.getUuid());
         return new PostInfoResponseDto(foundPost, nickname);
     }
 
-    // 판매 내역 리스트 정보
     @Override
     public List<MyPostListResponseDto> getMyPostList(String uuid) {
         checkValidationByUuid(uuid);
-        List<DealPost> allByUuid = dealRepository.findAllByUuid(uuid);
+        List<DealPost> allByUuid = dealRepository.findAllByUuidAndIsDeleted(uuid, false);
         return allByUuid.stream().map(MyPostListResponseDto::new).collect(Collectors.toList());
     }
 
     @Override
     public List<MainPagePostResponseDto> getDealPostLists() {
-        List<DealPost> dealPosts = dealRepository.findAllByStatus(SaleStatus.IN_PROGRESS);
+        List<DealPost> dealPosts = dealRepository.findAllByStatusAndIsDeleted(SaleStatus.IN_PROGRESS, false);
         return dealPosts.stream().map(MainPagePostResponseDto::new).collect(Collectors.toList());
     }
 
     @Override
     public void changePostStatus(String uuid, Long id) {
         checkValidationByUuid(uuid);
-        DealPost post = dealRepository.findDealPostById(id);
+        DealPost post = dealRepository.findDealPostByIdAndIsDeleted(id, false);
         post.changeStatus();
     }
 

--- a/deal-service/src/main/java/com/wesell/dealservice/service/DealServiceImpl.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/service/DealServiceImpl.java
@@ -3,14 +3,13 @@ package com.wesell.dealservice.service;
 import com.wesell.dealservice.domain.SaleStatus;
 import com.wesell.dealservice.dto.request.CreateDealPostRequestDto;
 import com.wesell.dealservice.dto.request.EditPostRequestDto;
-import com.wesell.dealservice.dto.response.EditPostResponseDto;
-import com.wesell.dealservice.dto.response.MainPagePostResponseDto;
-import com.wesell.dealservice.dto.response.MyPostListResponseDto;
-import com.wesell.dealservice.dto.response.PostInfoResponseDto;
+import com.wesell.dealservice.dto.response.*;
 import com.wesell.dealservice.domain.entity.Category;
 import com.wesell.dealservice.domain.entity.DealPost;
 import com.wesell.dealservice.domain.repository.CategoryRepository;
 import com.wesell.dealservice.domain.repository.DealRepository;
+import com.wesell.dealservice.error.ErrorCode;
+import com.wesell.dealservice.error.exception.CustomException;
 import com.wesell.dealservice.feignClient.UserFeignClient;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -47,6 +46,8 @@ public class DealServiceImpl implements DealService {
     // 거래 글 수정
     @Override
     public EditPostResponseDto editPost(EditPostRequestDto requestDto, Long postId) {
+        checkValidationByUuid(requestDto.getUuid());
+
         DealPost editPost = dealRepository.findDealPostByUuidAndId(requestDto.getUuid(), postId);
         editPost.editPost(requestDto);
         Category category = categoryRepository.findById(requestDto.getCategoryId()).get();
@@ -57,7 +58,8 @@ public class DealServiceImpl implements DealService {
 
     // 거래 글 삭제
     @Override
-    public void deletePost(Long postId) {
+    public void deletePost(String uuid, Long postId) {
+        checkValidationByUuid(uuid);
         dealRepository.deleteById(postId);
     }
 
@@ -72,6 +74,7 @@ public class DealServiceImpl implements DealService {
     // 판매 내역 리스트 정보
     @Override
     public List<MyPostListResponseDto> getMyPostList(String uuid) {
+        checkValidationByUuid(uuid);
         List<DealPost> allByUuid = dealRepository.findAllByUuid(uuid);
         return allByUuid.stream().map(MyPostListResponseDto::new).collect(Collectors.toList());
     }
@@ -83,9 +86,17 @@ public class DealServiceImpl implements DealService {
     }
 
     @Override
-    public void changePostStatus(Long id) {
+    public void changePostStatus(String uuid, Long id) {
+        checkValidationByUuid(uuid);
         DealPost post = dealRepository.findDealPostById(id);
         post.changeStatus();
+    }
+
+    public void checkValidationByUuid(String uuid) {
+        DealPost post = dealRepository.findDealPostByUuid(uuid);
+        if(!uuid.equals(post.getUuid())) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
     }
 
 }


### PR DESCRIPTION
1. 커스텀 에러 적용했습니다 -> 서비스 확장에 따라 추후 수정 가능성 있음
2. 피드백 반영해서 서비스 캡슐화와 컨트롤러 단순화를 위한 파사드 패턴 도입하여 리팩토링 진행했습니다.
3. 게시글 삭제 방법을 물리삭제에서 논리삭제로 변경했습니다. Boolean으로 isDeleted라는 값을 추가로 디비에 저장합니다. 유저쪽 처럼 트리거를 사용할까 고민했지만 성능 저하와 여러 문제가 발생한다고 판단되어 직관적으로 볼 수 있는 쉬운 방법을 선택했습니다.