### PR TITLE
feat: 판매 글 강제삭제 기능

### DIFF
--- a/admin-service/src/main/java/com/wesell/adminservice/controller/AdminController.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/controller/AdminController.java
@@ -1,7 +1,9 @@
 package com.wesell.adminservice.controller;
 
+import com.wesell.adminservice.domain.dto.request.AdminAuthIsForcedRequestDto;
 import com.wesell.adminservice.domain.dto.request.ChangeRoleRequestDto;
 import com.wesell.adminservice.domain.dto.request.SiteConfigRequestDto;
+import com.wesell.adminservice.domain.dto.response.AdminAuthIsForcedResponseDto;
 import com.wesell.adminservice.domain.dto.response.PostListResponseDto;
 import com.wesell.adminservice.domain.dto.response.SiteConfigResponseDto;
 import com.wesell.adminservice.domain.dto.response.UserListResponseDto;
@@ -66,5 +68,17 @@ public class AdminController {
     @GetMapping("get/post")
     public ResponseEntity<List<PostListResponseDto>> getPostList(@RequestParam("uuid") String uuid){
         return adminService.getPostList(uuid);
+    }
+
+    @PatchMapping("updateIsForced")
+    public ResponseEntity<AdminAuthIsForcedResponseDto> updateIsForced(@RequestBody AdminAuthIsForcedRequestDto requestDto) {
+        AdminAuthIsForcedResponseDto responseDto = adminService.updateIsForced(requestDto);
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
+
+    @PutMapping("deletePost")
+    public ResponseEntity<?> deletePost(@RequestParam("uuid") String uuid, @RequestParam("id") Long postId) {
+        adminService.deletePost(uuid, postId);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/admin-service/src/main/java/com/wesell/adminservice/domain/dto/request/AdminAuthIsForcedRequestDto.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/domain/dto/request/AdminAuthIsForcedRequestDto.java
@@ -1,0 +1,12 @@
+package com.wesell.adminservice.domain.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AdminAuthIsForcedRequestDto {
+    private String uuid;
+}

--- a/admin-service/src/main/java/com/wesell/adminservice/domain/dto/response/AdminAuthIsForcedResponseDto.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/domain/dto/response/AdminAuthIsForcedResponseDto.java
@@ -1,0 +1,12 @@
+package com.wesell.adminservice.domain.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AdminAuthIsForcedResponseDto {
+    private String message;
+}

--- a/admin-service/src/main/java/com/wesell/adminservice/feignClient/AuthFeignClient.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/feignClient/AuthFeignClient.java
@@ -1,8 +1,11 @@
 package com.wesell.adminservice.feignClient;
 
+import com.wesell.adminservice.domain.dto.request.AdminAuthIsForcedRequestDto;
 import com.wesell.adminservice.domain.dto.request.ChangeRoleRequestDto;
+import com.wesell.adminservice.domain.dto.response.AdminAuthIsForcedResponseDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,4 +15,7 @@ public interface AuthFeignClient {
 
     @PutMapping("change-role/{uuid}")
     ResponseEntity<String> changeUserRole (@PathVariable String uuid, @RequestBody ChangeRoleRequestDto changeRoleRequestDto);
+
+    @PatchMapping("updateIsForced")
+    ResponseEntity<AdminAuthIsForcedResponseDto> updateIsForced(@RequestBody AdminAuthIsForcedRequestDto requestDto);
 }

--- a/admin-service/src/main/java/com/wesell/adminservice/feignClient/DealFeignClient.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/feignClient/DealFeignClient.java
@@ -4,6 +4,7 @@ import com.wesell.adminservice.domain.dto.response.PostListResponseDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
@@ -11,6 +12,9 @@ import java.util.List;
 @FeignClient(name = "DEAL-SERVICE", path = "deal-service")
 public interface DealFeignClient {
 
-    @GetMapping("/list")
+    @GetMapping("list")
     ResponseEntity<List<PostListResponseDto>> getPostList(@RequestParam("uuid") String uuid);
+
+    @PutMapping("delete")
+    ResponseEntity<?> deletePost(@RequestParam("uuid") String uuid, @RequestParam("id") Long postId);
 }

--- a/admin-service/src/main/java/com/wesell/adminservice/service/AdminService.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/service/AdminService.java
@@ -2,7 +2,9 @@ package com.wesell.adminservice.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wesell.adminservice.domain.dto.request.AdminAuthIsForcedRequestDto;
 import com.wesell.adminservice.domain.dto.request.ChangeRoleRequestDto;
+import com.wesell.adminservice.domain.dto.response.AdminAuthIsForcedResponseDto;
 import com.wesell.adminservice.domain.dto.response.PostListResponseDto;
 import com.wesell.adminservice.domain.dto.response.UserListResponseDto;
 import com.wesell.adminservice.domain.entity.SiteConfig;
@@ -88,5 +90,13 @@ public class AdminService {
 
     public ResponseEntity<List<PostListResponseDto>> getPostList(String uuid) {
         return dealFeignClient.getPostList(uuid);
+    }
+
+    public AdminAuthIsForcedResponseDto updateIsForced(AdminAuthIsForcedRequestDto requestDto) {
+        return authFeignClient.updateIsForced(requestDto).getBody();
+    }
+
+    public void deletePost(String uuid, Long postId) {
+        dealFeignClient.deletePost(uuid, postId);
     }
 }

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AdminAuthController.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AdminAuthController.java
@@ -1,6 +1,8 @@
 package com.wesell.authenticationserver.controller;
 
+import com.wesell.authenticationserver.dto.request.AdminAuthIsForcedRequestDto;
 import com.wesell.authenticationserver.dto.request.AdminAuthRoleRequestDto;
+import com.wesell.authenticationserver.dto.response.AdminAuthIsForcedResponseDto;
 import com.wesell.authenticationserver.service.AdminAuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,6 +23,12 @@ public class AdminAuthController {
         } catch (Exception e) {
             return new ResponseEntity<>("Failed to change user role: " + e.getMessage(), HttpStatus.BAD_REQUEST);
         }
+    }
+
+    @PatchMapping("updateIsForced")
+    public ResponseEntity<AdminAuthIsForcedResponseDto> updateIsForced(@RequestBody AdminAuthIsForcedRequestDto requestDto) {
+        AdminAuthIsForcedResponseDto responseDto = adminAuthService.updateIsForced(requestDto);
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 }
 

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/dto/request/AdminAuthIsForcedRequestDto.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/dto/request/AdminAuthIsForcedRequestDto.java
@@ -1,0 +1,14 @@
+package com.wesell.authenticationserver.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminAuthIsForcedRequestDto {
+    private String uuid;
+}

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/dto/response/AdminAuthIsForcedResponseDto.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/dto/response/AdminAuthIsForcedResponseDto.java
@@ -1,0 +1,14 @@
+package com.wesell.authenticationserver.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminAuthIsForcedResponseDto {
+    private String message;
+}

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/service/AdminAuthService.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/service/AdminAuthService.java
@@ -3,7 +3,8 @@ package com.wesell.authenticationserver.service;
 import com.wesell.authenticationserver.domain.entity.AuthUser;
 import com.wesell.authenticationserver.domain.enum_.Role;
 import com.wesell.authenticationserver.domain.repository.AdminAuthUserRepository;
-import com.wesell.authenticationserver.domain.repository.AuthUserRepository;
+import com.wesell.authenticationserver.dto.request.AdminAuthIsForcedRequestDto;
+import com.wesell.authenticationserver.dto.response.AdminAuthIsForcedResponseDto;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,6 +22,28 @@ public class AdminAuthService {
         if (user != null) {
             user.changeRole(newRole);
             adminAuthUserRepository.save(user);
+        }
+    }
+
+    public AdminAuthIsForcedResponseDto updateIsForced(AdminAuthIsForcedRequestDto requestDto) {
+        AuthUser authUser = adminAuthUserRepository.findByUuid(requestDto.getUuid());
+
+        if (authUser != null) {
+            AuthUser updatedAuthUser = AuthUser.builder()
+                    .id(authUser.getId())
+                    .email(authUser.getEmail())
+                    .password(authUser.getPassword())
+                    .uuid(authUser.getUuid())
+                    .role(authUser.getRole())
+                    .isDelete(authUser.isDelete())
+                    .isForced(true)
+                    .build();
+
+            adminAuthUserRepository.save(updatedAuthUser);
+
+            return new AdminAuthIsForcedResponseDto(requestDto.getUuid() + " UUID를 가진 사용자가 강제 탈퇴로 표시되었습니다.");
+        } else {
+            return new AdminAuthIsForcedResponseDto(requestDto.getUuid() + " UUID를 가진 사용자를 찾을 수 없습니다.");
         }
     }
 }


### PR DESCRIPTION
# 코드리뷰전 반드시 확인 !!!! 시간이 부족한 관계로 다른 PR이 닫히기 전에 PR을 올려서 중복 내용이 많습니다.
### 커밋 된 부분 ( 확인할 부분 )
### 1. AdminController 클래스
`@PutMapping("deletePost")
    public ResponseEntity<?> deletePost(@RequestParam("uuid") String uuid, @RequestParam("id") Long postId) {
        adminService.deletePost(uuid, postId);
        return new ResponseEntity<>(HttpStatus.OK);
    }` 
### 2. DealFeignClient 클래스
` @PutMapping("delete")
    ResponseEntity<?> deletePost(@RequestParam("uuid") String uuid, @RequestParam("id") Long postId);`

### 강제 삭제 기능이지만 우선 delete만 수행함
- 강제 삭제가 필요할까 싶은 생각이 들었는데
- 강제 삭제를 수행한다면 isForced를 true로 하고 
`"관리자가 삭제한 페이지입니다."` 이런식으로 하면 되지않을까 생각만 하는중..

