### PR TITLE
feat: 관리자페이지 회원 목록 조회 관련 Feign 서비스 구현

### DIFF
--- a/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AuthFeignController.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AuthFeignController.java
@@ -1,0 +1,22 @@
+package com.wesell.authenticationserver.controller;
+
+import com.wesell.authenticationserver.dto.feign.AuthUserListFeignResponseDto;
+import com.wesell.authenticationserver.service.AuthUserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthFeignController {
+
+    private final AuthUserService authUserService;
+
+    @GetMapping("feign/auth-list")
+    public List<AuthUserListFeignResponseDto> authUserListFeignToUser(){
+        return authUserService.getAllForFeign();
+    }
+
+}

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/dto/feign/AuthUserListFeignResponseDto.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/dto/feign/AuthUserListFeignResponseDto.java
@@ -1,0 +1,15 @@
+package com.wesell.authenticationserver.dto.feign;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthUserListFeignResponseDto {
+
+    private String uuid;
+    private String email;
+    private String role;
+}

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/CustomConverter.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/CustomConverter.java
@@ -4,9 +4,14 @@ import com.wesell.authenticationserver.domain.entity.AuthUser;
 import com.wesell.authenticationserver.domain.entity.TokenInfo;
 import com.wesell.authenticationserver.domain.enum_.Role;
 import com.wesell.authenticationserver.dto.GeneratedTokenDto;
+import com.wesell.authenticationserver.dto.feign.AuthUserListFeignResponseDto;
 import com.wesell.authenticationserver.dto.request.CreateUserRequestDto;
 import com.wesell.authenticationserver.dto.response.CreateUserFeignResponseDto;
 import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 // 기능 : dto <-> entity || dto <-> dto(OpenFeign 시)
 @Component
@@ -32,7 +37,7 @@ public class CustomConverter {
     /*---------------------------------------------------------------------------*/
 
     /**
-     * dto -> feignDto
+     * dto/entity -> feignDto
      */
 
     public CreateUserFeignResponseDto toFeignDto(CreateUserRequestDto createUserRequestDto){
@@ -43,6 +48,16 @@ public class CustomConverter {
                 .agree(createUserRequestDto.isAgree())
                 .phone(createUserRequestDto.getPhone())
                 .build();
+    }
+
+    public List<AuthUserListFeignResponseDto> toFeignDto(List<AuthUser> authUserList){
+        return authUserList.stream().map(
+                user->AuthUserListFeignResponseDto.builder()
+                        .uuid(user.getUuid())
+                        .email(user.getEmail())
+                        .role(user.getRole().toString())
+                        .build()
+        ).collect(Collectors.toList());
     }
 
     /*---------------------------------------------------------------------------*/

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/service/AuthUserService.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/service/AuthUserService.java
@@ -5,6 +5,7 @@ import com.wesell.authenticationserver.domain.entity.TokenInfo;
 import com.wesell.authenticationserver.domain.repository.AuthUserRepository;
 import com.wesell.authenticationserver.dto.GeneratedTokenDto;
 import com.wesell.authenticationserver.dto.LoginSuccessDto;
+import com.wesell.authenticationserver.dto.feign.AuthUserListFeignResponseDto;
 import com.wesell.authenticationserver.dto.request.CreateUserRequestDto;
 import com.wesell.authenticationserver.dto.request.LoginUserRequestDto;
 import com.wesell.authenticationserver.global.util.CustomConverter;
@@ -18,6 +19,7 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -88,5 +90,11 @@ public class AuthUserService {
         return authUserRepository.findByUuid(uuid).orElseThrow(
                 () -> new CustomException(ErrorCode.NOT_SIGNUP_USER)
         );
+    }
+
+    /*====================== Feign =======================*/
+    public List<AuthUserListFeignResponseDto> getAllForFeign(){
+        List<AuthUser> authUserList = authUserRepository.findAll();
+        return customConverter.toFeignDto(authUserList);
     }
 }


### PR DESCRIPTION
🎇 Auth -> User Feign
- User-service에서 인증 인가 서버측 정보(email, role)를 feign 요청을 위한 Auth 측 기능 구현.
- uuid를 함께 보내주는 이유는!! user-service db 내 저장된 회원 정보와 인증/인가 서버에서 보내준 데이터를 매핑하기 위해서이다.