### PR TITLE
test: jwt filter 검증 & fix: error 발생 부분 로직 수정.

### DIFF
--- a/apigateway-server/src/main/java/com/wesell/apigatewayserver/filter/AuthorizationCheckFilter.java
+++ b/apigateway-server/src/main/java/com/wesell/apigatewayserver/filter/AuthorizationCheckFilter.java
@@ -1,16 +1,15 @@
 package com.wesell.apigatewayserver.filter;
 
+import com.wesell.apigatewayserver.global.TokenValidator;
+import com.wesell.apigatewayserver.global.enum_.Role;
 import com.wesell.apigatewayserver.response.CustomException;
 import com.wesell.apigatewayserver.response.ErrorCode;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.impl.DefaultClaims;
 import lombok.Data;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
-import org.springframework.core.env.Environment;
 import org.springframework.http.HttpCookie;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
@@ -20,24 +19,23 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 import org.springframework.util.MultiValueMap;
 import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 @Log4j2
 public class AuthorizationCheckFilter extends AbstractGatewayFilterFactory<AuthorizationCheckFilter.Config> {
 
-    private final Environment env;
-    private final TokenProperties tokenProperties;
-    private final UserDetailsService userDetailsService;
+    private final TokenValidator tokenValidator;
+    private final UserDetailsServiceImpl userDetailsService;
 
-    public AuthorizationCheckFilter(Environment env, TokenProperties tokenProperties,
-                                    UserDetailsService userDetailsService) {
+    public AuthorizationCheckFilter(TokenValidator tokenValidator, UserDetailsServiceImpl userDetailsService) {
         super(Config.class);
-        this.env = env;
-        this.tokenProperties = tokenProperties;
+        this.tokenValidator = tokenValidator;
         this.userDetailsService = userDetailsService;
     }
 
@@ -47,20 +45,31 @@ public class AuthorizationCheckFilter extends AbstractGatewayFilterFactory<Autho
             ServerHttpRequest req = exchange.getRequest();
             ServerHttpResponse resp = exchange.getResponse();
             MultiValueMap<String,HttpCookie> cookies = req.getCookies();
-            Claims claims = new DefaultClaims();
 
             //pre-filter
             if(!cookies.isEmpty()){
-                if(cookies.containsKey("access-token") && !req.getHeaders().containsKey(HttpHeaders.AUTHORIZATION)){
 
-                    String accessToken = cookies.get("access-token").toString();
+                List<String> cookieValues = cookies.get("access-token").stream()
+                        .filter(c -> "access-token".equals(c.getName())).map(HttpCookie::getValue).toList();
 
+                if(!cookieValues.isEmpty() && req.getHeaders().get(HttpHeaders.AUTHORIZATION) == null){
+                    String accessToken = cookieValues.get(0);
                     try{
-                        claims = Jwts.parser()
-                                .setSigningKey(tokenProperties.getSecretKey())
-                                .requireIssuer(tokenProperties.getIssuer())
-                                .parseClaimsJws(accessToken)
-                                .getBody();
+                        Claims claims = tokenValidator.validateToken(accessToken);
+
+                        Authentication authentication = SecurityContextHolder
+                                .getContext().getAuthentication();
+
+                        if(authentication == null) {
+                            String uuid = claims.getSubject();
+                            String role = claims.get("role",String.class);
+
+                            userDetailsService.registerRole(role);
+                            UserDetails userDetails = userDetailsService.loadUserByUsername(uuid);
+                            authentication = new UsernamePasswordAuthenticationToken(userDetails
+                                    ,"",userDetails.getAuthorities());
+                            SecurityContextHolder.getContext().setAuthentication(authentication);
+                        }
                     }catch(ExpiredJwtException exception){
                         throw new CustomException(ErrorCode.EXPIRED_JWT_TOKEN);
                     }catch(Exception e){
@@ -69,22 +78,7 @@ public class AuthorizationCheckFilter extends AbstractGatewayFilterFactory<Autho
                 }
             }
 
-            Claims finalClaims = claims;
             return chain.filter(exchange).then(Mono.fromRunnable(()->{
-
-                // ContextHolder에 Context 저장 / Context 삭제
-                if(req.getURI().getPath().contains("/sign-in")
-                        && resp.getStatusCode() == HttpStatusCode.valueOf(200)){
-                    String uuid = finalClaims.getSubject();
-                    Authentication authentication =SecurityContextHolder.getContext().getAuthentication();
-
-                    if(authentication ==null) {
-                        UserDetails userDetails = userDetailsService.loadUserByUsername(uuid);
-                        authentication = new UsernamePasswordAuthenticationToken(userDetails
-                                ,"",userDetails.getAuthorities());
-                        SecurityContextHolder.getContext().setAuthentication(authentication);
-                    }
-                }
 
                 if(req.getURI().getPath().contains("/logout")
                         && resp.getStatusCode() == HttpStatusCode.valueOf(200)){

--- a/apigateway-server/src/main/java/com/wesell/apigatewayserver/filter/UserDetailsImpl.java
+++ b/apigateway-server/src/main/java/com/wesell/apigatewayserver/filter/UserDetailsImpl.java
@@ -3,7 +3,7 @@ package com.wesell.apigatewayserver.filter;
 import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-
+import java.util.ArrayList;
 import java.util.Collection;
 
 @Getter
@@ -14,7 +14,7 @@ import java.util.Collection;
 public class UserDetailsImpl implements UserDetails {
 
     private String uuid;
-    private Collection<GrantedAuthority> authorities;
+    private Collection<GrantedAuthority> authorities = new ArrayList<>();
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/apigateway-server/src/main/java/com/wesell/apigatewayserver/global/TokenValidator.java
+++ b/apigateway-server/src/main/java/com/wesell/apigatewayserver/global/TokenValidator.java
@@ -1,0 +1,23 @@
+package com.wesell.apigatewayserver.global;
+
+import com.wesell.apigatewayserver.filter.TokenProperties;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TokenValidator {
+
+    private final TokenProperties tokenProperties;
+
+    public Claims validateToken(String accessToken) throws Exception{
+        return Jwts.parser()
+                .setSigningKey(tokenProperties.getSecretKey())
+                .requireIssuer(tokenProperties.getIssuer())
+                .parseClaimsJws(accessToken)
+                .getBody();
+    }
+
+}

--- a/apigateway-server/src/main/java/com/wesell/apigatewayserver/global/config/SecurityConfig.java
+++ b/apigateway-server/src/main/java/com/wesell/apigatewayserver/global/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.wesell.apigatewayserver.global.config;
 
-import com.wesell.apigatewayserver.filter.TokenProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,9 +10,6 @@ import org.springframework.security.web.server.SecurityWebFilterChain;
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
-
-    private final TokenProperties tokenProperties;
-//    private final UserDetailsServiceImpl userDetailsService;
 
     /**
      * 인증 인가 과정을 거치지 않도록 처리한 설정 - swagger
@@ -44,7 +40,7 @@ public class SecurityConfig {
                 // 권한 확인 설정 - 추후 세부적으로 구분 예정
                 .authorizeExchange(ex -> ex
                         .pathMatchers("/admin-service/*").hasRole("ADMIN")
-                        .pathMatchers("/auth-server/health-check").authenticated()
+                        .pathMatchers("/auth-server/health-check").hasAuthority("USER")
                         .anyExchange().permitAll()
                 );
 


### PR DESCRIPTION
🎆 gateway jwt 필터 테스트 결과
- ServerHttpRequest에서 access-token 추출하는 과정에서 잘못 추출하여, 내부에 name과 함께 value가 문자열로 저장됨.
- debug 모드로 실행하여, String 변수에 저장된 값 확인 후 해당 부분 로직 수정함.
- 현재 access-token 순수값이 전달됨을 확인함.

🎆 권한 filtering 테스트 결과
- SpringContextHolder에 UsernamePasswordAuthenticationToken 을 담았으나, 권한 확인 및 filtering 되지 않음.
- 현재 원인 추정으로 SecurityWebFilterChain 으로 비동기식으로 필터링하도록 구현하였으나, SpringContextHolder에 저장된 권한을 기준으로 filtering 되지 않는 것으로 보인다.
- HttpSecurity에서 SecurityWebFilterChain으로 변경한 이유는 Netty 서버 내에서 HttpSecurity 및 SecurityFilterChain 사용 시, bean으로 적재되지 않는? 현상이 발생되어 변경함.
- 이번주 주말에 다시 테스트 예정임.

> 확인 사항
1. HttpSecurity 적용 시, 오류가 발생하는 원인 파악.
2. SecurityWebFilterChain을 사용한 Authentication 등록 방식 및 권한 필터링 여부 테스트.