### PR TITLE
feat: 유저 검색 기능 구현

### DIFF
--- a/admin-service/src/main/java/com/wesell/adminservice/controller/AdminController.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/controller/AdminController.java
@@ -2,9 +2,11 @@ package com.wesell.adminservice.controller;
 
 import com.wesell.adminservice.dto.request.ChangeRoleRequestDto;
 import com.wesell.adminservice.dto.response.AdminAuthIsForcedResponseDto;
+import com.wesell.adminservice.dto.response.AdminUserResponseDto;
 import com.wesell.adminservice.dto.response.PostListResponseDto;
 import com.wesell.adminservice.dto.response.UserListResponseDto;
 import com.wesell.adminservice.service.AdminService;
+import com.wesell.adminservice.service.VersionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,17 +14,18 @@ import org.springframework.web.bind.annotation.*;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
 public class AdminController {
 
     private final AdminService adminService;
+    private final VersionService versionService;
 
     @GetMapping("get-version")
     public ResponseEntity<Map<String, String>> getVersions() {
-        Map<String, String> currentVersions = adminService.getVersions();
-        return new ResponseEntity<>(currentVersions, HttpStatus.OK);
+        return new ResponseEntity<>(versionService.getVersions(), HttpStatus.OK);
     }
 
     @GetMapping("get/users")
@@ -40,7 +43,7 @@ public class AdminController {
         versions.put("jsVersion", jsVersion);
         versions.put("cssVersion", cssVersion);
         versions.put("title", title);
-        adminService.setVersions(versions);
+        versionService.setVersions(versions);
         return new ResponseEntity<>(versions, HttpStatus.OK);
     }
 
@@ -61,13 +64,20 @@ public class AdminController {
 
     @PutMapping("updateIsForced/{uuid}")
     public ResponseEntity<AdminAuthIsForcedResponseDto> updateIsForced(@PathVariable String uuid) {
-        AdminAuthIsForcedResponseDto responseDto = adminService.updateIsForced(uuid);
-        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+        return new ResponseEntity<>(adminService.updateIsForced(uuid), HttpStatus.OK);
     }
 
     @PutMapping("deletePost")
     public ResponseEntity<?> deletePost(@RequestParam("uuid") String uuid, @RequestParam("id") Long postId) {
         adminService.deletePost(uuid, postId);
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @GetMapping("search")
+    public List<AdminUserResponseDto> searchUsers(@RequestParam("name") Optional<String> name,
+                                                  @RequestParam("nickname") Optional<String> nickname,
+                                                  @RequestParam("phone") Optional<String> phone,
+                                                  @RequestParam("uuid") Optional<String> uuid) {
+        return adminService.searchUsers(name, nickname, phone, uuid);
     }
 }

--- a/admin-service/src/main/java/com/wesell/adminservice/dto/response/AdminUserResponseDto.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/dto/response/AdminUserResponseDto.java
@@ -1,0 +1,13 @@
+package com.wesell.adminservice.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AdminUserResponseDto {
+    private String name;
+    private String nickname;
+    private String phone;
+    private String uuid;
+}

--- a/admin-service/src/main/java/com/wesell/adminservice/feignClient/UserFeignClient.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/feignClient/UserFeignClient.java
@@ -1,9 +1,11 @@
 package com.wesell.adminservice.feignClient;
 
+import com.wesell.adminservice.dto.response.AdminUserResponseDto;
 import com.wesell.adminservice.dto.response.UserListResponseDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import java.util.List;
 
 @FeignClient(name="USER-SERVICE")
@@ -11,4 +13,12 @@ public interface UserFeignClient {
 
     @GetMapping("users")
     ResponseEntity<List<UserListResponseDto>> getUserList();
+
+    @GetMapping("search-users")
+    List<AdminUserResponseDto> searchUsers(
+            @RequestParam("name") String name,
+            @RequestParam("nickname") String nickname,
+            @RequestParam("phone") String phone,
+            @RequestParam("uuid") String uuid
+    );
 }

--- a/admin-service/src/main/java/com/wesell/adminservice/service/AdminService.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/service/AdminService.java
@@ -2,6 +2,7 @@ package com.wesell.adminservice.service;
 
 import com.wesell.adminservice.dto.request.ChangeRoleRequestDto;
 import com.wesell.adminservice.dto.response.AdminAuthIsForcedResponseDto;
+import com.wesell.adminservice.dto.response.AdminUserResponseDto;
 import com.wesell.adminservice.dto.response.PostListResponseDto;
 import com.wesell.adminservice.dto.response.UserListResponseDto;
 import com.wesell.adminservice.feignClient.AuthFeignClient;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -22,14 +24,6 @@ public class AdminService {
     private final UserFeignClient userFeignClient;
     private final AuthFeignClient authFeignClient;
     private final DealFeignClient dealFeignClient;
-
-    private Map<String, String> versions = new HashMap<>();
-    public void setVersions(Map<String, String> versions) {
-        this.versions = versions;
-    }
-    public Map<String, String> getVersions(){
-        return this.versions;
-    }
 
     public ResponseEntity<List<UserListResponseDto>> getUserList(){
         return userFeignClient.getUserList();
@@ -55,5 +49,19 @@ public class AdminService {
 
     public void deletePost(String uuid, Long postId) {
         dealFeignClient.deletePost(uuid, postId);
+    }
+
+    public List<AdminUserResponseDto> searchUsers(Optional<String> name,
+                                                  Optional<String> nickname,
+                                                  Optional<String> phone,
+                                                  Optional<String> uuid) {
+
+        // 각 Optional 파라미터가 비어있지 않으면 해당 값을 사용하고, 비어있으면 무시
+        String searchName = name.orElse(null);
+        String searchNickname = nickname.orElse(null);
+        String searchPhone = phone.orElse(null);
+        String searchUuid = uuid.orElse(null);
+
+        return userFeignClient.searchUsers(searchName, searchNickname, searchPhone, searchUuid);
     }
 }

--- a/admin-service/src/main/java/com/wesell/adminservice/service/VersionService.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/service/VersionService.java
@@ -1,0 +1,14 @@
+package com.wesell.adminservice.service;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.stereotype.Service;
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@Setter
+@Service
+public class VersionService {
+    private Map<String, String> versions = new HashMap<>();
+}

--- a/admin-service/src/main/resources/application.yml
+++ b/admin-service/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 0
+  port: 8887
 
 spring:
   application:

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AdminAuthController.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AdminAuthController.java
@@ -17,14 +17,12 @@ public class AdminAuthController {
 
     @PutMapping("change-role")
     public ResponseEntity<AdminAuthResponseDto> changeUserRole(@RequestBody AdminAuthRoleRequestDto requestDto) {
-        AdminAuthResponseDto responseDto = authUserService.updateRole(requestDto.getUuid(), requestDto.getRole());
-        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+        return new ResponseEntity<>(authUserService.updateRole(requestDto.getUuid(), requestDto.getRole()), HttpStatus.OK);
     }
 
     @PutMapping("updateIsForced/{uuid}")
     public ResponseEntity<AdminAuthResponseDto> updateIsForced(@PathVariable String uuid) {
-        AdminAuthResponseDto responseDto = authUserService.updateIsForced(uuid);
-        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+        return new ResponseEntity<>(authUserService.updateIsForced(uuid), HttpStatus.OK);s
     }
 }
 

--- a/user-service/src/main/java/com/wesell/userservice/controller/AdminUserController.java
+++ b/user-service/src/main/java/com/wesell/userservice/controller/AdminUserController.java
@@ -1,0 +1,28 @@
+package com.wesell.userservice.controller;
+
+import com.wesell.userservice.dto.request.AdminUserRequestDto;
+import com.wesell.userservice.dto.response.AdminUserResponseDto;
+import com.wesell.userservice.service.AdminUserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminUserController {
+
+    private final AdminUserService userService;
+
+    @GetMapping("search-users")
+    public List<AdminUserResponseDto> searchUsers(@RequestParam("name") String name,
+                                                  @RequestParam("nickname") String nickname,
+                                                  @RequestParam("phone") String phone,
+                                                  @RequestParam("uuid") String uuid) {
+        return userService.searchUsers(name, nickname, phone, uuid);
+    }
+}

--- a/user-service/src/main/java/com/wesell/userservice/domain/repository/AdminUserRepository.java
+++ b/user-service/src/main/java/com/wesell/userservice/domain/repository/AdminUserRepository.java
@@ -1,0 +1,12 @@
+package com.wesell.userservice.domain.repository;
+
+import com.wesell.userservice.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface AdminUserRepository extends JpaRepository<User, Long> {
+    List<User> findByNameContaining(String name);
+    List<User> findByNicknameContaining(String nickname);
+    List<User> findByPhoneContaining(String phone);
+    List<User> findByUuidContaining(String uuid);
+}

--- a/user-service/src/main/java/com/wesell/userservice/dto/request/AdminUserRequestDto.java
+++ b/user-service/src/main/java/com/wesell/userservice/dto/request/AdminUserRequestDto.java
@@ -1,0 +1,17 @@
+package com.wesell.userservice.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AdminUserRequestDto {
+    private String name;
+    private String nickname;
+    private String phone;
+    private String uuid;
+}

--- a/user-service/src/main/java/com/wesell/userservice/dto/response/AdminUserResponseDto.java
+++ b/user-service/src/main/java/com/wesell/userservice/dto/response/AdminUserResponseDto.java
@@ -1,0 +1,15 @@
+package com.wesell.userservice.dto.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AdminUserResponseDto {
+    private String name;
+    private String nickname;
+    private String phone;
+    private String uuid;
+}

--- a/user-service/src/main/java/com/wesell/userservice/service/AdminUserService.java
+++ b/user-service/src/main/java/com/wesell/userservice/service/AdminUserService.java
@@ -1,0 +1,56 @@
+package com.wesell.userservice.service;
+
+import com.wesell.userservice.domain.entity.User;
+import com.wesell.userservice.domain.repository.AdminUserRepository;
+import com.wesell.userservice.dto.request.AdminUserRequestDto;
+import com.wesell.userservice.dto.response.AdminUserResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Service
+@RequiredArgsConstructor
+public class AdminUserService {
+
+    private final AdminUserRepository adminUserRepository;
+
+    public List<AdminUserResponseDto> searchUsers(String name,
+                                                  String nickname,
+                                                  String phone,
+                                                  String uuid){
+
+        // 검색 결과를 UserSearchResponseDTO로 변환
+        List<AdminUserResponseDto> responseDtos = convertToResponseDtos(
+                adminUserRepository.findByNameContaining(name),
+                adminUserRepository.findByNicknameContaining(nickname),
+                adminUserRepository.findByPhoneContaining(phone),
+                adminUserRepository.findByUuidContaining(uuid)
+        );
+
+        return responseDtos;
+    }
+
+    private List<AdminUserResponseDto> convertToResponseDtos(
+            List<User> usersByName,
+            List<User> usersByNickname,
+            List<User> usersByPhone,
+            List<User> usersByUuid) {
+
+        // 검색 결과 리스트의 크기를 가져옴
+        int minSize = Math.min(Math.min(usersByName.size(), usersByNickname.size()), Math.min(usersByPhone.size(), usersByUuid.size()));
+
+        // 검색 결과를 변환하여 리스트로 반환
+        return IntStream.range(0, minSize)
+                .mapToObj(i -> AdminUserResponseDto.builder()
+                        .name(usersByName.get(i).getName())
+                        .nickname(usersByNickname.get(i).getNickname())
+                        .phone(usersByPhone.get(i).getPhone())
+                        .uuid(usersByUuid.get(i).getUuid())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
### 기존 PR 피드백 적용
```java
// Map<String, String> currentVersions = adminService.getVersions();
//         return new ResponseEntity<>(currentVersions, HttpStatus.OK);
return new ResponseEntity<>(versionService.getVersions(), HttpStatus.OK);
``` 
- 메시지들 상수로 저장해서 따로 관리하는게 어떠냐고도 했었는데 까먹음 ㅎ!
```java
return new ResponseEntity<>("User role changed successfully", HttpStatus.OK);
``` 
### VersionService 생성
- 인메모리 방식으로 저장하는 사이트설정 값을 AdminService에 같이 작성해뒀었는데 코드 일관성을 위해 VersionService로 분리
```java
@Getter @Setter @Service
public class VersionService {
    private Map<String, String> versions = new HashMap<>();
}
``` 
### 유저 검색 기능 구현
- 각 검색 요소마다 따로 매핑을 줄 수도 있지만 너무 비효율적이라고 판단해서 하나로 합침
- 요소들 중 몇개만 입력해도 입력하지 않은 요소들은 무시하고 검색 가능하도록 @RequestParam에 Optional로 값을 받음
```java
// 각 Optional 파라미터가 비어있지 않으면 해당 값을 사용하고, 비어있으면 무시
        String searchName = name.orElse(null);
        String searchNickname = nickname.orElse(null);
        String searchPhone = phone.orElse(null);
        String searchUuid = uuid.orElse(null);
``` 
