### PR TITLE
feat:마이페이지 email FeignTest 및 softdelete 구현

### DIFF
--- a/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AdminAuthController.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AdminAuthController.java
@@ -24,5 +24,9 @@ public class AdminAuthController {
     public ResponseEntity<AdminAuthResponseDto> updateIsForced(@PathVariable String uuid) {
         return new ResponseEntity<>(authUserService.updateIsForced(uuid), HttpStatus.OK);
     }
+    @PutMapping("updateIsDeleted/{uuid}")
+    public ResponseEntity<AdminAuthResponseDto> updateIsDeleted(@PathVariable String uuid) {
+        return new ResponseEntity<>(authUserService.updateIsDeleted(uuid), HttpStatus.OK);
+    }
 }
 

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/domain/entity/AuthUser.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/domain/entity/AuthUser.java
@@ -37,6 +37,10 @@ public class AuthUser {
         isForced = !isForced;
     }
 
+    public void changeIsDelted(){
+        isDelete = !isDelete;
+    }
+
     public void changePassword(String newPassword) {
         this.password = newPassword;
     }

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/SmsUtil.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/SmsUtil.java
@@ -30,7 +30,7 @@ public class SmsUtil {
     public void sendOne(String to, String verificationCode) {
         Message message = new Message();
         // 발신번호 및 수신번호는 반드시 01012345678 형태로 입력되어야 합니다.
-        message.setFrom("phoneNumber");
+        message.setFrom("01025246373");
         message.setTo(to.trim());
         message.setText("아래의 인증번호를 입력해주세요 \n" + verificationCode);
 

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/service/AuthUserService.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/service/AuthUserService.java
@@ -110,6 +110,10 @@ public class AuthUserService {
 
     }
 
+<<<<<<< Updated upstream
+=======
+    @Transactional
+>>>>>>> Stashed changes
     public AdminAuthResponseDto updateRole(String uuid, Role newRole) {
         Optional<AuthUser> optionalUser = authUserRepository.findById(uuid);
         if (optionalUser.isPresent()) {
@@ -128,6 +132,19 @@ public class AuthUserService {
             AuthUser authUser = optionalUser.get();
             authUser.changeIsForced();
             return new AdminAuthResponseDto(uuid + " UUID를 가진 사용자의 강제 탈퇴 여부가 변경되었습니다.");
+        } else {
+            return new AdminAuthResponseDto(uuid + " UUID를 가진 사용자를 찾을 수 없습니다.");
+        }
+    }
+
+    @Transactional
+    public AdminAuthResponseDto updateIsDeleted(String uuid) {
+        Optional<AuthUser> optionalUser = authUserRepository.findById(uuid);
+
+        if (optionalUser.isPresent()) {
+            AuthUser authUser = optionalUser.get();
+            authUser.changeIsDelted();
+            return new AdminAuthResponseDto(uuid + " UUID를 가진 사용자의 삭제 여부가 변경되었습니다.");
         } else {
             return new AdminAuthResponseDto(uuid + " UUID를 가진 사용자를 찾을 수 없습니다.");
         }

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/service/feign/UserServiceFeignClient.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/service/feign/UserServiceFeignClient.java
@@ -6,7 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@FeignClient(name="USER-SERVICE")
+@FeignClient(name="USER-SERVICE", path="user-service")
 public interface UserServiceFeignClient {
 
     @PostMapping("api/sign-up")

--- a/authentication-server/src/main/resources/application.yml
+++ b/authentication-server/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 0
+  port: 8081
 
 spring:
   application:

--- a/user-service/src/main/java/com/wesell/userservice/controller/UserController.java
+++ b/user-service/src/main/java/com/wesell/userservice/controller/UserController.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("user-service")
 public class UserController {
 
     private final UserService userService;
@@ -48,7 +49,7 @@ public class UserController {
         }
     }
 
-    @PostMapping("/api/signup")
+    @PostMapping("api/sign-up")
     public ResponseEntity<String> signup(@RequestBody SignupRequestDto signupRequestDTO) {
 
         try {
@@ -64,6 +65,16 @@ public class UserController {
 
         try {
             userService.updateUser(uuid, signupRequestDTO);
+            return new ResponseEntity<>("User updated successfully", HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>("User update failed: " + e.getMessage(), HttpStatus.BAD_REQUEST);
+        }
+    }
+    @PutMapping("isforced/{uuid}")
+    public ResponseEntity<String> updateisforced(@PathVariable String uuid, @RequestBody SignupRequestDto signupRequestDTO) {
+
+        try {
+            userService.isforced(uuid, signupRequestDTO);
             return new ResponseEntity<>("User updated successfully", HttpStatus.OK);
         } catch (Exception e) {
             return new ResponseEntity<>("User update failed: " + e.getMessage(), HttpStatus.BAD_REQUEST);

--- a/user-service/src/main/java/com/wesell/userservice/domain/entity/User.java
+++ b/user-service/src/main/java/com/wesell/userservice/domain/entity/User.java
@@ -38,11 +38,18 @@ public class User {
     @Column(name = "u_agree", nullable = false)
     private boolean agree;
 
+    @ColumnDefault(value = "false")
+    @Column(name = "u_isforced", nullable = false)
+    private boolean isforced;
 
     public User changeUserInfo(String name) {
         this.name = name;
         updateCreatedAt();
         return this;
+    }
+
+    public void changeUserisforced(boolean isforced){
+        this.isforced = isforced;
     }
 
     public void updateCreatedAt() {

--- a/user-service/src/main/java/com/wesell/userservice/dto/request/SignupRequestDto.java
+++ b/user-service/src/main/java/com/wesell/userservice/dto/request/SignupRequestDto.java
@@ -15,4 +15,5 @@ public class SignupRequestDto {
     private String phone;
     private String uuid;
     private boolean agree;
+    private boolean isforced;
 }

--- a/user-service/src/main/java/com/wesell/userservice/service/UserService.java
+++ b/user-service/src/main/java/com/wesell/userservice/service/UserService.java
@@ -59,6 +59,7 @@ public class UserService {
                 .phone(userdto.getPhone())
                 .agree(userdto.isAgree())
                 .uuid(userdto.getUuid())
+                .isforced(userdto.isIsforced())
                 .build();
     }
 
@@ -74,6 +75,17 @@ public class UserService {
             User updatedUser = optionalUser.get();
             User user = updatedUser.changeUserInfo(signupRequestDTO.getName());
             userRepository.update(user);
+        } else {
+            throw new EntityNotFoundException("User not found with uuid: " + uuid);
+        }
+    }
+    @Transactional
+    public void isforced(String uuid, SignupRequestDto signupRequestDTO) {
+        Optional<User> optionalUser = userRepository.findByOneId(uuid);
+
+        if (optionalUser.isPresent()) {
+            User updatedUser = optionalUser.get();
+            updatedUser.changeUserisforced(signupRequestDTO.isIsforced());
         } else {
             throw new EntityNotFoundException("User not found with uuid: " + uuid);
         }

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
마이페이지 emial FeignTest 검증 후 softdelete 구현했습니다.

softdelete -> adminservice가 authserver db에 회원삭제되었다고 메세지를 보냈을 때 is_delete가 false에서 true로 바뀌는 코드구현했습니다. 