### PR TITLE
feat: 각 기능 예외처리

### DIFF
--- a/admin-service/src/main/java/com/wesell/adminservice/controller/AdminController.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/controller/AdminController.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("api/v1")
 public class AdminController {
 
     private final AdminService adminService;
@@ -42,12 +43,8 @@ public class AdminController {
 
     @PutMapping("change-role")
     public ResponseEntity<String> changeUserRole(@RequestBody ChangeRoleRequestDto requestDto) {
-        try {
-            adminService.changeUserRole(requestDto);
-            return new ResponseEntity<>("User role changed successfully", HttpStatus.OK);
-        } catch (Exception e) {
-            return new ResponseEntity<>("Failed to change user role: " + e.getMessage(), HttpStatus.BAD_REQUEST);
-        }
+        adminService.changeUserRole(requestDto);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 
     @GetMapping("get/post")
@@ -59,13 +56,13 @@ public class AdminController {
 
     @PutMapping("updateIsForced/{uuid}")
     public ResponseEntity<String> updateIsForced(@PathVariable String uuid) {
-        return new ResponseEntity<>(adminService.updateIsForced(uuid), HttpStatus.OK);
+        return new ResponseEntity<>(adminService.userIsForced(uuid), HttpStatus.OK);
     }
 
     @PutMapping("deletePost")
     public ResponseEntity<?> deletePost(@RequestParam("uuid") String uuid,
                                         @RequestParam("id") Long postId) {
-        adminService.deletePost(uuid, postId);
+        adminService.postIsDeleted(uuid, postId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 

--- a/admin-service/src/main/java/com/wesell/adminservice/dto/response/ErrorResponseDto.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/dto/response/ErrorResponseDto.java
@@ -1,0 +1,30 @@
+package com.wesell.adminservice.dto.response;
+
+import com.wesell.adminservice.error.InternalServerException;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+public class ErrorResponseDto {
+
+    private final String timestamp;
+    private final String trackingId;
+    private final HttpStatus status;
+    private final String code;
+    private final List<Object> message;
+    private final String detailMessage;
+
+    public ErrorResponseDto(InternalServerException e) {
+        this.timestamp = LocalDateTime.now().toString();
+        this.trackingId = UUID.randomUUID().toString();
+        this.status = e.getErrorCode().getStatus();
+        this.code = e.getClass().getSimpleName();
+        this.message = List.of(e.getErrorCode().getMessage());
+        this.detailMessage = e.getMessage();
+    }
+}

--- a/admin-service/src/main/java/com/wesell/adminservice/error/ErrorCode.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/error/ErrorCode.java
@@ -1,0 +1,24 @@
+package com.wesell.adminservice.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    NOT_FOUND(HttpStatus.BAD_REQUEST, "COMMON-ERR-404", "페이지를 찾을 수 없습니다."),
+    INTERNAL_SERVER_ERROR_GET_USER_LIST(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-ERR-500", "유저 전체 목록 조회 오류 발생"),
+    INTERNAL_SERVER_ERROR_CHANGE_USER_ROLE(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-ERR-500", "회원 권한 변경 오류 발생"),
+    INTERNAL_SERVER_ERROR_GET_POST_LIST(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-ERR-500", "글 목록 조회 오류 발생"),
+    INTERNAL_SERVER_ERROR_USER_ISFORCED(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-ERR-500", "회원 강제 탈퇴 오류 발생"),
+    INTERNAL_SERVER_ERROR_POST_ISDELETED(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-ERR-500", "글 강제 삭제 오류 발생"),
+    INTERNAL_SERVER_ERROR_SEARCH_USERS(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-ERR-500", "회원 목록 검색 오류 발생");
+
+
+    private final HttpStatus status;
+    private final String errorCode;
+    private final String message;
+
+}

--- a/admin-service/src/main/java/com/wesell/adminservice/error/GlobalExceptionHandler.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/error/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.wesell.adminservice.error;
+
+import com.wesell.adminservice.dto.response.ErrorResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(InternalServerException.class)
+    protected ResponseEntity<ErrorResponseDto> userExceptionHandler(InternalServerException e) {
+        ErrorResponseDto dto = new ErrorResponseDto(e);
+        log.error("Error occurred in controller advice: [id={}]", dto.getTrackingId());
+        return ResponseEntity.status(e.getErrorCode().getStatus()).body(dto);
+    }
+}

--- a/admin-service/src/main/java/com/wesell/adminservice/error/InternalServerException.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/error/InternalServerException.java
@@ -1,0 +1,14 @@
+package com.wesell.adminservice.error;
+
+import lombok.Getter;
+
+@Getter
+public class InternalServerException extends RuntimeException{
+
+    ErrorCode errorCode;
+
+    public InternalServerException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/admin-service/src/main/java/com/wesell/adminservice/feignClient/AuthFeignClient.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/feignClient/AuthFeignClient.java
@@ -5,7 +5,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@FeignClient(name="AUTHENTICATION-SERVER", path = "admin-auth-server")
+@FeignClient(name = "AUTHENTICATION-SERVER", path = "api/v1")
 public interface AuthFeignClient {
 
     @PutMapping("change-role")

--- a/admin-service/src/main/java/com/wesell/adminservice/feignClient/DealFeignClient.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/feignClient/DealFeignClient.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
-@FeignClient(name = "DEAL-SERVICE")
+@FeignClient(name = "DEAL-SERVICE", path = "api/v1")
 public interface DealFeignClient {
 
     @GetMapping("admin/list")

--- a/admin-service/src/main/java/com/wesell/adminservice/feignClient/UserFeignClient.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/feignClient/UserFeignClient.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import java.util.List;
 
-@FeignClient(name="USER-SERVICE")
+@FeignClient(name = "USER-SERVICE", path = "api/v1")
 public interface UserFeignClient {
 
     @GetMapping("user-list")

--- a/admin-service/src/main/java/com/wesell/adminservice/service/AdminService.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/service/AdminService.java
@@ -4,15 +4,16 @@ import com.wesell.adminservice.dto.request.ChangeRoleRequestDto;
 import com.wesell.adminservice.dto.response.AdminUserResponseDto;
 import com.wesell.adminservice.dto.response.PostListResponseDto;
 import com.wesell.adminservice.dto.response.UserListResponseDto;
+import com.wesell.adminservice.error.ErrorCode;
+import com.wesell.adminservice.error.InternalServerException;
 import com.wesell.adminservice.feignClient.AuthFeignClient;
 import com.wesell.adminservice.feignClient.DealFeignClient;
 import com.wesell.adminservice.feignClient.UserFeignClient;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,42 +22,59 @@ public class AdminService {
     private final UserFeignClient userFeignClient;
     private final AuthFeignClient authFeignClient;
     private final DealFeignClient dealFeignClient;
+    private static final Logger logger = LoggerFactory.getLogger(AdminService.class);
 
-    public Page<UserListResponseDto> getUserList(int page, int size){
-        return userFeignClient.getUserList(page, size);
-    }
-
-    public void changeUserRole(ChangeRoleRequestDto requestDto) {
-        ResponseEntity<String> response = authFeignClient.changeUserRole(requestDto);
-
-        if (response.getStatusCode() == HttpStatus.OK) {
-            System.out.println("User role changed successfully");
-        } else {
-            System.out.println("Failed to change user role: " + response.getBody());
+    public Page<UserListResponseDto> getUserList(int page, int size) {
+        try {
+            return userFeignClient.getUserList(page, size);
+        } catch (Exception e) {
+            logger.error("유저 전체 목록 조회 오류 발생", e);
+            throw new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR_GET_USER_LIST);
         }
     }
 
-    public Page<PostListResponseDto> getPostList(String uuid,
-                                                 int page,
-                                                 int size) {
-        return dealFeignClient.getPostList(uuid, page, size);
+    public void changeUserRole(ChangeRoleRequestDto requestDto) {
+        try {
+            authFeignClient.changeUserRole(requestDto);
+        } catch (Exception e) {
+            logger.error("회원 권한 변경 오류 발생", e);
+            throw new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR_CHANGE_USER_ROLE);
+        }
     }
 
-    public String updateIsForced(String uuid) {
-        return authFeignClient.updateIsForced(uuid).getBody();
+    public Page<PostListResponseDto> getPostList(String uuid, int page, int size) {
+        try {
+            return dealFeignClient.getPostList(uuid, page, size);
+        } catch (Exception e) {
+            logger.error("글 목록 조회 오류 발생", e);
+            throw new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR_GET_POST_LIST);
+        }
     }
 
-    public void deletePost(String uuid, Long postId) {
-        dealFeignClient.deletePost(uuid, postId);
+    public String userIsForced(String uuid) {
+        try {
+            return authFeignClient.updateIsForced(uuid).getBody();
+        } catch (Exception e) {
+            logger.error("회원 강제 탈퇴 오류 발생", e);
+            throw new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR_USER_ISFORCED);
+        }
     }
 
-    public Page<AdminUserResponseDto> searchUsers(String name,
-                                                  String nickname,
-                                                  String phone,
-                                                  String uuid,
-                                                  int page,
-                                                  int size) {
+    public void postIsDeleted(String uuid, Long postId) {
+        try {
+            dealFeignClient.deletePost(uuid, postId);
+        } catch (Exception e) {
+            logger.error("글 강제 삭제 오류 발생", e);
+            throw new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR_POST_ISDELETED);
+        }
+    }
 
-        return userFeignClient.searchUsers(name, nickname, phone, uuid, page, size);
+    public Page<AdminUserResponseDto> searchUsers(String name, String nickname, String phone, String uuid, int page, int size) {
+        try {
+            return userFeignClient.searchUsers(name, nickname, phone, uuid, page, size);
+        } catch (Exception e) {
+            logger.error("회원 목록 검색 오류 발생", e);
+            throw new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR_SEARCH_USERS);
+        }
     }
 }

--- a/admin-service/src/main/java/com/wesell/adminservice/service/VersionService.java
+++ b/admin-service/src/main/java/com/wesell/adminservice/service/VersionService.java
@@ -12,6 +12,19 @@ import java.util.Map;
 public class VersionService {
     private Map<String, String> versions = new HashMap<>();
 
+    // 생성자를 통해 초기값 설정
+    public VersionService(String jsVersion, String cssVersion, String title, String agree) {
+        versions.put("jsVersion", jsVersion);
+        versions.put("cssVersion", cssVersion);
+        versions.put("title", title);
+        versions.put("agree", agree);
+    }
+
+    public VersionService() {
+        // 기본값을 원하는 값으로 설정
+        this("1.0", "1.0", "Default Title", "개인정보 제공에 동의하십니까?");
+    }
+
     public Map<String, String> setVersions(String jsVersion, String cssVersion, String title, String agree) {
         versions.put("jsVersion", jsVersion);
         versions.put("cssVersion", cssVersion);

--- a/apigateway-server/src/main/resources/application.yml
+++ b/apigateway-server/src/main/resources/application.yml
@@ -30,16 +30,22 @@ spring:
           uri: lb://USER-SERVICE
           predicates:
             - Path=/user-service/**
+          filters:
+            - RewritePath=/user-service/(?<path>.*),/$\{path}
 
         - id: admin-service
           uri: lb://ADMIN-SERVICE
           predicates:
             - Path=/admin-service/**
+          filters:
+            - RewritePath=/admin-service/(?<path>.*),/$\{path}
 
         - id: deal-service
           uri: lb://DEAL-SERVICE
           predicates:
             - Path=/deal-service/**
+          filters:
+            - RewritePath=/deal-service/(?<path>.*),/$\{path}
 
         - id: authentication-server
           uri: lb://AUTHENTICATION-SERVER

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AdminAuthController.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AdminAuthController.java
@@ -9,7 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("admin-auth-server")
+@RequestMapping("api/v1")
 @RequiredArgsConstructor
 public class AdminAuthController {
 

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/service/feign/UserServiceFeignClient.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/service/feign/UserServiceFeignClient.java
@@ -6,10 +6,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@FeignClient(name="USER-SERVICE")
+@FeignClient(name = "USER-SERVICE", path = "api/v1")
 public interface UserServiceFeignClient {
 
-    @PostMapping("api/sign-up")
+    @PostMapping("api/signup")
     ResponseEntity<String> registerUserDetailInfo(@RequestBody CreateUserFeignResponseDto dto);
 
     @PostMapping("feign/find/id")

--- a/deal-service/src/main/java/com/wesell/dealservice/controller/AdminDealController.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/controller/AdminDealController.java
@@ -5,11 +5,13 @@ import com.wesell.dealservice.service.AdminDealService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("api/v1")
 public class AdminDealController {
     private final AdminDealService adminDealService;
 

--- a/user-service/src/main/java/com/wesell/userservice/controller/AdminUserController.java
+++ b/user-service/src/main/java/com/wesell/userservice/controller/AdminUserController.java
@@ -6,11 +6,13 @@ import com.wesell.userservice.service.AdminUserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("api/v1")
 public class AdminUserController {
 
     private final AdminUserService adminUserService;

--- a/user-service/src/main/java/com/wesell/userservice/controller/UserController.java
+++ b/user-service/src/main/java/com/wesell/userservice/controller/UserController.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("api/v1")
 public class UserController {
 
     private final UserService userService;

--- a/user-service/src/main/java/com/wesell/userservice/service/AdminUserService.java
+++ b/user-service/src/main/java/com/wesell/userservice/service/AdminUserService.java
@@ -13,8 +13,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor


### PR DESCRIPTION
### 접두사 제거 및 그에따른 매핑 수정
```java
// @RequestMapping("admin-service")
@RequestMapping("api/v1")
``` 
### 메서드 이름 변경
- 예외를 enum으로 정리하다보니 메서드 이름이 명확하지않은거같아서 변경함
```java
// adminService.updateIsForced(uuid)
adminService.userIsForced(uuid)

// adminService.deletePost(uuid, postId);
adminService.postIsDeleted(uuid, postId);
``` 
### 내부 서버 오류 예외 작성 ( InternalServerException.java )
- RuntimeException을 상속받음
### ExceptionHandler 작성 ( GlobalExceptionHandler.java )
- 예외처리를 프론트에 전달해주는 역할
### 각 에러코드 enum 상수로 지정 ( ErrorCode.java )
```java
NOT_FOUND(HttpStatus.BAD_REQUEST, "COMMON-ERR-404", "페이지를 찾을 수 없습니다."),
INTERNAL_SERVER_ERROR_GET_USER_LIST(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-ERR-500", "유저 전체 목록 조회 오류 발생"),
INTERNAL_SERVER_ERROR_CHANGE_USER_ROLE(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-ERR-500", "회원 권한 변경 오류 발생"),
INTERNAL_SERVER_ERROR_GET_POST_LIST(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-ERR-500", "글 목록 조회 오류 발생"),
INTERNAL_SERVER_ERROR_USER_ISFORCED(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-ERR-500", "회원 강제 탈퇴 오류 발생"),
INTERNAL_SERVER_ERROR_POST_ISDELETED(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-ERR-500", "글 강제 삭제 오류 발생"),
INTERNAL_SERVER_ERROR_SEARCH_USERS(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-ERR-500", "회원 목록 검색 오류 발생");
``` 
- 404 에러는 쓰일것 같아서 선언만 해두고 아직 사용되진않음
### apigateway-server RewritePath 작성

```java
filters:
  - RewritePath=/admin-service/(?<path>.*),/$\{path}
``` 

<details><summary>RewritePath 작성한 이유</summary>
<p>
게이트웨이에서 각 서버의 Actuator나 다른 라이브러리에서 제공하는 엔드포인트를 접속 시 문제가 생기는데, 이런 현상을 해결하기 위해 아래와 같은 구조로 변경 해야한다.
<aside>

> 💡 client → (접두어가 붙은 엔드포인트) → gateway → (그냥 엔드포인트) → 각 ms Layer

</aside>
클라이언트에서 요청할때는 접두어가 붙어서 레이어를 구분할 수 있게 하고 게이트 웨이가 인식을 마치면 접두어를 뺀 엔드포인트로 요청을 보내 각 ms에서 RestApi 규격 + 라이브러리 엔드포인트 규격을 지킬 수 있게 하는 것이다.
</p>
</details> 