### PR TITLE
feat: [Front & Auth] 회원가입&로그인 api 통신 테스트 및 로직 수정

### DIFF
--- a/apigateway-server/src/main/resources/application.yml
+++ b/apigateway-server/src/main/resources/application.yml
@@ -12,19 +12,7 @@ spring:
             message: Spring Cloud Gateway GlobalFilter Message
             showPreLogger: true
             showPostLogger: true
-      globalcors:
-        cors-configurations:
-          '[/**]':
-            allowedOrigins: 'http://localhost:3000'
-            allow-credentials: true
-            allowedHeaders: '*'
-            allowedMethods:
-              - PUT
-              - GET
-              - POST
-              - DELETE
-              - PATCH
-              - OPTIONS
+
       routes:
         - id: user-service
           uri: lb://USER-SERVICE
@@ -54,6 +42,7 @@ spring:
           filters:
             - RewritePath=/auth-server/(?<path>.*),/$\{path}
             - AuthorizationCheckFilter
+
 
 eureka:
   instance:

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AuthController.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AuthController.java
@@ -40,7 +40,7 @@ public class AuthController {
 
     // 회원가입
     @PostMapping("sign-up")
-    public ResponseEntity<String> signUp(@Valid @RequestBody CreateUserRequestDto requestDto){
+    public ResponseEntity<?> signUp(@Valid @RequestBody CreateUserRequestDto requestDto){
 
         log.debug("AuthController - 회원가입");
 

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/controller/CertificatePhoneController.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/controller/CertificatePhoneController.java
@@ -7,15 +7,15 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-//@RequestMapping("user-service")
+@RequestMapping("api/v1")
 @RequiredArgsConstructor
 public class CertificatePhoneController {
 
     private final SmsUtil smsUtil;
 
 
-    @PostMapping("/phone/id/validate")
-    public ResponseEntity<?> sendSMSById(@RequestBody String phoneNumber) {
+    @GetMapping("/phone/validate")
+    public ResponseEntity<?> sendSMSById(@RequestParam String phoneNumber) {
 
         String numStr = smsUtil.createCode();
         System.out.println(phoneNumber);
@@ -25,13 +25,4 @@ public class CertificatePhoneController {
         return ResponseEntity.ok(phoneNumber);
     }
 
-    @PostMapping("/phone/pwd/validate")
-    public ResponseEntity<?> sendSMSByPWD(@RequestBody String phoneNumber) {
-
-        String numStr = smsUtil.createCode();
-        System.out.println(phoneNumber);
-        smsUtil.sendOne(phoneNumber, numStr);
-
-        return ResponseEntity.ok(new Message());
-    }
 }

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/controller/response/ErrorControllerAdvisor.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/controller/response/ErrorControllerAdvisor.java
@@ -1,32 +1,27 @@
 package com.wesell.authenticationserver.controller.response;
 
+import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
+@Log4j2
 public class ErrorControllerAdvisor {
 
     /**
-     * springframework.validation 에러 메시지 처리
+     * 유효성 검증 에러 메시지 처리
      * @return ResponseEntity<String>
      */
     @ExceptionHandler(value = BindException.class)
-    protected ResponseEntity<String> handleBindException(BindException e){
-
-        StringBuilder errorMessage = new StringBuilder("필수 입력 항목을 전부 입력해주세요! : \n");
-
-        for (FieldError fieldError : e.getFieldErrors()) {
-            errorMessage.append(fieldError.getField())
-                    .append(" - ")
-                    .append(fieldError.getDefaultMessage())
-                    .append("\n");
-        }
-
+    protected ResponseEntity<ResponseDto> handleBindException(BindException e){
+        e.getFieldErrors().stream().forEach(
+            b-> log.error("[ValidationFail] 오류 메시지 : field:{}, message: {}"
+                    ,b.getField(),b.getDefaultMessage())
+        );
         return ResponseEntity.status(ErrorCode.VALIDATION_FAIL.getStatus())
-                .body(errorMessage.toString());
+                .body(ResponseDto.of(e));
     }
 
     /**
@@ -35,10 +30,9 @@ public class ErrorControllerAdvisor {
      */
     @ExceptionHandler(value = CustomException.class)
     protected ResponseEntity<ResponseDto> handleCustomException(CustomException e){
-
+        log.error("[Error] 에러 발생 ! errorCode : {}, errorMessage : {}",e.errorCode,e.getMessage());
         return ResponseEntity
                 .status(e.getErrorCode().getStatus())
                 .body(ResponseDto.of(e));
-
     }
 }

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/domain/entity/AuthUser.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/domain/entity/AuthUser.java
@@ -25,8 +25,10 @@ public class AuthUser {
     @Column(name= "a_role", nullable = false)
     private Role role;
 
+    @Column(name = "is_deleted")
     private boolean isDeleted; // 삭제 여부
 
+    @Column(name = "is_forced")
     private boolean isForced; // 강제 탈퇴 여부
 
     public void changeRole(Role role){

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/CustomConverter.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/CustomConverter.java
@@ -60,7 +60,6 @@ public class CustomConverter {
                 .build();
     }
 
-<<<<<<< HEAD
     public CreateUserFeignResponseDto toFeignDto(KakaoAccount kakaoAccount, String uuid){
         return CreateUserFeignResponseDto.builder()
                 .name(kakaoAccount.getName())

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/CustomCookie.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/CustomCookie.java
@@ -1,10 +1,7 @@
 package com.wesell.authenticationserver.global.util;
 
-import jakarta.servlet.http.Cookie;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
-import java.util.Arrays;
-import java.util.Optional;
 
 //JWT를 담을 쿠키 생성 및 기한 만료 기능 구현
 @Component
@@ -25,7 +22,6 @@ public class CustomCookie {
 
         return ResponseCookie.from("savedEmail",email)
                 .path("/")
-                .httpOnly(true)
                 .maxAge(60 * 60 *24)
                 .build();
 
@@ -43,17 +39,7 @@ public class CustomCookie {
     public ResponseCookie deleteSavedEmailCookie(){
         return ResponseCookie.from("savedEmail")
                 .path("/")
-                .httpOnly(true)
                 .maxAge(0)
                 .build();
     }
-
-    // 토큰 조회
-    public Optional<Cookie> getJwt(Cookie[] cookies){
-
-        return Arrays.stream(cookies)
-                .filter(c -> "access-token".equals(c.getName())).findFirst();
-
-    }
-
 }

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/service/AuthUserService.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/service/AuthUserService.java
@@ -1,5 +1,6 @@
 package com.wesell.authenticationserver.service;
 
+import com.wesell.authenticationserver.controller.response.ResponseDto;
 import com.wesell.authenticationserver.domain.entity.AuthUser;
 import com.wesell.authenticationserver.domain.enum_.Role;
 import com.wesell.authenticationserver.domain.repository.AuthUserRepository;
@@ -43,12 +44,12 @@ public class AuthUserService {
      * 회원 가입 기능
      */
     @Transactional
-    public ResponseEntity<String> createUser(CreateUserRequestDto createUserRequestDto){
+    public ResponseEntity<ResponseDto> createUser(CreateUserRequestDto createUserRequestDto){
         log.debug("회원 가입 시작");
 
         log.debug("uuid 생성, 비밀번호 암호화, 회원 인증 정보 엔티티로 convert");
-        String pw = passwordEncoder.encode(createUserRequestDto.getPw()); // 암호화
         String uuid = UUID.randomUUID().toString();
+        String pw = passwordEncoder.encode(createUserRequestDto.getPw()); // 암호화
         createUserRequestDto.setUuid(uuid);
         createUserRequestDto.setPw(pw);
         AuthUser user = customConverter.toEntity(createUserRequestDto);

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/service/feign/UserServiceFeignClient.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/service/feign/UserServiceFeignClient.java
@@ -1,5 +1,6 @@
 package com.wesell.authenticationserver.service.feign;
 
+import com.wesell.authenticationserver.controller.response.ResponseDto;
 import com.wesell.authenticationserver.service.dto.response.CreateUserFeignResponseDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
@@ -9,9 +10,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 @FeignClient(name="USER-SERVICE")
 public interface UserServiceFeignClient {
 
-    @PostMapping("api/sign-up")
-    ResponseEntity<String> registerUserDetailInfo(@RequestBody CreateUserFeignResponseDto dto);
+    @PostMapping("api/v1/sign-up")
+    ResponseEntity<ResponseDto> registerUserDetailInfo(@RequestBody CreateUserFeignResponseDto dto);
 
-    @PostMapping("feign/find/id")
+    @PostMapping("api/v1/feign/find/id")
     String findID(@RequestBody String phoneNumber);
 }

--- a/front-server/package-lock.json
+++ b/front-server/package-lock.json
@@ -18,6 +18,7 @@
         "axios": "^1.6.2",
         "http-proxy-middleware": "^2.0.6",
         "react": "^18.2.0",
+        "react-cookie": "^6.1.1",
         "react-dom": "^18.2.0",
         "react-loader-spinner": "^5.4.5",
         "react-hook-form": "^7.48.2",
@@ -4000,6 +4001,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.4.tgz",
+      "integrity": "sha512-7z/eR6O859gyWIAjuvBWFzNURmf2oPBmJlfVWkwehU5nzIyjwBsTh7WMmEEV4JFnHuQ3ex4oyTvfKzcyJVDBNA=="
+    },
     "node_modules/@types/eslint": {
       "version": "8.44.8",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.8.tgz",
@@ -4051,6 +4057,15 @@
       "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
+      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
       }
     },
     "node_modules/@types/html-minifier-terser": {
@@ -14488,6 +14503,19 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
+    "node_modules/react-cookie": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-6.1.1.tgz",
+      "integrity": "sha512-fuFRpf8LH6SfmVMowDUIRywJF5jAUDUWrm0EI5VdXfTl5bPcJ7B0zWbuYpT0Tvikx7Gs18MlvAT+P+744dUz2g==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "hoist-non-react-statics": "^3.3.2",
+        "universal-cookie": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -16800,6 +16828,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/universal-cookie": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-6.1.1.tgz",
+      "integrity": "sha512-33S9x3CpdUnnjwTNs2Fgc41WGve2tdLtvaK2kPSbZRc5pGpz2vQFbRWMxlATsxNNe/Cy8SzmnmbuBM85jpZPtA==",
+      "dependencies": {
+        "@types/cookie": "^0.5.1",
+        "cookie": "^0.5.0"
       }
     },
     "node_modules/universalify": {

--- a/front-server/package.json
+++ b/front-server/package.json
@@ -13,6 +13,7 @@
     "axios": "^1.6.2",
     "http-proxy-middleware": "^2.0.6",
     "react": "^18.2.0",
+    "react-cookie": "^6.1.1",
     "react-dom": "^18.2.0",
     "react-loader-spinner": "^5.4.5",
     "react-hook-form": "^7.48.2",

--- a/front-server/src/App.tsx
+++ b/front-server/src/App.tsx
@@ -9,7 +9,6 @@ import CorsTest from 'pages/Test';
 import Social from 'pages/Social/kakao';
 import UploadBoard from 'pages/board/post/Post';
 
-
 // component: Application 컴포넌트 //
 function App() {
   // render: Application 컴포넌트 랜더링 //

--- a/front-server/src/apis/index.ts
+++ b/front-server/src/apis/index.ts
@@ -1,67 +1,82 @@
 import axios from 'axios';
 import { SignInRequestDto, SignUpRequestDto } from './request/auth';
-import { SignInResponseDto, SignUpResponseDto } from './response/auth';
+import { SignInResponseDto } from './response/auth';
 import { ResponseDto } from './response';
 
-const AUTH_DOMAIN = 'http://localhost:8000/auth-server';
-
-const API_DOMAIN = `${AUTH_DOMAIN}/api/v1`;
-
-const SIGN_IN_URL = () => `${API_DOMAIN}/sign-in`;
-const SIGN_UP_URL = () => `${API_DOMAIN}/sign-up`;
-const NICKNAME_CHECK_URL = () => `${API_DOMAIN}/dup-check`;
-const KAKAO_CALLBACK_URL = () => `${API_DOMAIN}/kakao/auth-code`;
+const SIGN_IN_URL = () => '/auth-server/api/v1/sign-in';
+const SIGN_UP_URL = () => '/auth-server/api/v1/sign-up';
+const NICKNAME_CHECK_URL = () => '/user-service/api/v1/dup-check';
+const PHONE_CHECK_URL = () => '/auth-service/api/v1/phone/validate';
+const KAKAO_CALLBACK_URL = () => `/auth-server/api/v1/kakao/auth-code`;
 
 export const signInRequest = async (requestBody: SignInRequestDto) => {
   try {
+    console.log(requestBody);
     const response = await axios.post(SIGN_IN_URL(), requestBody);
     const responseBody: SignInResponseDto = response.data;
     return responseBody;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
-    if (!error.response.data) return null;
+    if (!error.response) return null;
     const responseBody: ResponseDto = error.response.data;
     return responseBody;
   }
 };
 
-export const nicknameDupCheckRequest = async (nickname: string) => {
+export const nicknameDupCheckRequest = async (param: string) => {
   try {
-    const response = await axios.post(NICKNAME_CHECK_URL(), nickname);
+    const response = await axios.get(NICKNAME_CHECK_URL(), {
+      params: { nickname: param },
+    });
     const responseBody: ResponseDto = response.data;
     return responseBody;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
-    if (!error.response.data) return null;
+    if (!error.response) return null;
     const responseBody: ResponseDto = error.response.data;
     return responseBody;
   }
 };
+
+export const phoneValidateRequest = async (param: string) => {
+  try{
+    const response = await axios.get(PHONE_CHECK_URL(),{
+      params: {phone : param}
+    });
+    const responseBody: ResponseDto = response.data;
+    return responseBody;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }catch(error : any){
+    if(!error.response) return null;
+    const responseBody : ResponseDto = error.response.data;
+    return responseBody;
+  }
+}
 
 export const signUpRequest = async (requestBody: SignUpRequestDto) => {
   try {
     const response = await axios.post(SIGN_UP_URL(), requestBody);
-    const responseBody: SignUpResponseDto = response.data;
+    const responseBody:ResponseDto = response.data;
     return responseBody;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
-    if (!error.response.data) return null;
+    if (!error.response) return null;
     const responseBody: ResponseDto = error.response.data;
     return responseBody;
   }
 };
 
-// comment: 인가 코드 인증 서버로 보내기 //
-export const kakaoCallbackAuthCodeRequest = async (authCode : string | null) => {
-  try{
-    const response = await axios.post(KAKAO_CALLBACK_URL(),authCode);
+export const kakaoCallbackAuthCodeRequest = async (authCode: string | null) => {
+  try {
+    const response = await axios.post(KAKAO_CALLBACK_URL(), authCode);
     const resonseBody: ResponseDto = response.data;
     return resonseBody;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  }catch(error: any){
-    if(!error.response.data) return null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (error: any) {
+    if (!error.response) return null;
     const responseBody: ResponseDto = error.response.data;
     return responseBody;
   }
 };
+

--- a/front-server/src/apis/request/auth/sign-in.request.dto.ts
+++ b/front-server/src/apis/request/auth/sign-in.request.dto.ts
@@ -1,5 +1,5 @@
 export default interface SingInRequestDto {
   email: string;
   password: string;
-  savedId: boolean;
+  savedEmail: boolean;
 }

--- a/front-server/src/apis/request/auth/sign-up.request.dto.ts
+++ b/front-server/src/apis/request/auth/sign-up.request.dto.ts
@@ -3,7 +3,7 @@ export default interface SignUpRequestDto {
   nickname: string;
   phone: string;
   email: string;
-  password: string;
-  passwordCheck: string;
+  pw: string;
+  pwRe: string;
   agree: boolean;
 }

--- a/front-server/src/apis/response/auth/sign-in.response.dto.ts
+++ b/front-server/src/apis/response/auth/sign-in.response.dto.ts
@@ -1,4 +1,7 @@
 import ResponseDto from '../response.dto';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export default interface SignInResponseDto extends ResponseDto {}
+export default interface SignInResponseDto extends ResponseDto {
+  uuid: string;
+  role: string;
+}

--- a/front-server/src/apis/response/response.dto.ts
+++ b/front-server/src/apis/response/response.dto.ts
@@ -5,5 +5,5 @@ export default interface ResponseDto {
   status: string;
   code: ResponseCode;
   message: string;
-  detail: string;
+  vfMessages?: string[];
 }

--- a/front-server/src/components/ButtonBox/index.tsx
+++ b/front-server/src/components/ButtonBox/index.tsx
@@ -3,18 +3,18 @@ interface Props {
   label: string;
   type: 'button' | 'submit' | 'reset' | undefined;
   onClick?: () => void;
+  isEnable: boolean;
 }
 
 // component: Button Box 컴포넌트 //
 const ButtonBox = (props: Props) => {
-  const { label, type, onClick } = props;
+  const { label, type, onClick, isEnable } = props;
 
   // render: Button Box 컴포넌트 렌더링 //
   return (
     <div className="button-box">
-      <button className="btn " type={type} onClick={onClick}>
-        {label}
-      </button>
+      {isEnable && <button className="enable-btn" type={type} onClick={onClick}>{label}</button>}
+      {!isEnable && <button className="disable-btn" type={type} disabled>{label}</button>}
     </div>
   );
 };

--- a/front-server/src/components/ButtonBox/style.css
+++ b/front-server/src/components/ButtonBox/style.css
@@ -1,0 +1,18 @@
+.enable-btn{
+  background-color: #4CAF50; /* Green */
+  border: none;
+  color: white;
+  padding: 15px 32px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 16px;
+  margin: 4px 2px;
+  cursor: pointer;
+}
+
+.disable-btn{
+    background-color: #dddddd; /* Light gray */
+    color: #666666; /* Dark gray */
+    cursor: not-allowed;
+}

--- a/front-server/src/components/CheckBox/index.tsx
+++ b/front-server/src/components/CheckBox/index.tsx
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import './style.css';
 
 // interface: Check Box 컴포넌트 Props //
@@ -9,11 +8,12 @@ interface Props {
   checked: boolean;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  message?: string;
 }
 
 // component: Check Box 컴포넌트 //
 const CheckBox = (props: Props) => {
-  const { id, label, name, checked } = props;
+  const { id, label, name, checked, message,} = props;
   const { onChange, onKeyDown } = props;
 
   // event-handler: on Key-Down 이벤트 처리 함수 //
@@ -34,6 +34,8 @@ const CheckBox = (props: Props) => {
         checked={checked}
       />
       <label htmlFor={id}>{label}</label>
+
+      {message && (<span className='checkbox-message'>{message}</span>)}
     </>
   );
 };

--- a/front-server/src/components/CheckBox/style.css
+++ b/front-server/src/components/CheckBox/style.css
@@ -6,3 +6,8 @@
   margin: 5px;
   font-weight: 550;
 }
+.checkbox-message{
+  color: rgba(255,0,0,0.8);
+  font-size: 12px;
+  font-weight: 300;
+}

--- a/front-server/src/components/InputBox/index.tsx
+++ b/front-server/src/components/InputBox/index.tsx
@@ -25,12 +25,6 @@ const InputBox = forwardRef<HTMLInputElement, Props>((props: Props, ref) => {
   const { type, name, placeholder, error, value, icon, message } = props;
   const { onChange, onIconClick, onClick, onKeyDown } = props;
 
-  // // event-handler: input 값 변경 이벤트 처리 함수 //
-  // const onChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
-  //   const { value } = event.target;
-  //   setValue(value);
-  // };
-
   // event-handler: on Key-Down 이벤트 처리 함수 //
   const onKeyDownHandler = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (!onKeyDown) return;

--- a/front-server/src/components/InputBox/style.css
+++ b/front-server/src/components/InputBox/style.css
@@ -3,22 +3,23 @@
   flex-direction: column;
 
   width: 300px;
+  margin-bottom: 10px;
 }
 
 .inputbox-container {
   padding: 15px 30px 15px 15px;
+  margin-bottom: 20px;
 
   display: flex;
   align-items: cetner;
 
   box-shadow: 1px 1px 4px 1px rgba(0, 0, 0, 0.2);
   border-radius: 10px;
-  margin-bottom: 10px;
 }
 
 .inputbox-container-error {
   border-bottom: 1px solid rgba(255, 0, 0, 0.7);
-  padding: 11px 16px 11px 0px;
+  padding: 15px 30px 15px 15px;
 
   background-color: rgba(255, 250, 250, 1);
 
@@ -40,10 +41,12 @@
   text-indent: 5px;
 }
 
-.input-box-message {
+.inputbox-message {
   color: rgba(255, 0, 0, 0.7);
 
-  font-size: 10px;
-  font-weight: 400;
+  font-size: 12px;
+  font-weight: 500;
   line-height: 140%;
+
+  padding-top: 5px;
 }

--- a/front-server/src/pages/Authentication/index.tsx
+++ b/front-server/src/pages/Authentication/index.tsx
@@ -1,18 +1,24 @@
-import InputBox from 'components/InputBox';
-import { useState, useRef, KeyboardEvent, ChangeEvent } from 'react';
 import './style.css';
-import CheckBox from 'components/CheckBox';
-import { SignInRequestDto } from 'apis/request/auth';
-import { nicknameDupCheckRequest, signInRequest } from 'apis';
+import { nicknameDupCheckRequest, phoneValidateRequest, signInRequest, signUpRequest } from 'apis';
+import { useState, useRef, KeyboardEvent, ChangeEvent, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { SignInRequestDto, SignUpRequestDto } from 'apis/request/auth';
 import { SignInResponseDto } from 'apis/response/auth';
 import { ResponseDto } from 'apis/response';
 import ButtonBox from 'components/ButtonBox';
+import InputBox from 'components/InputBox';
+import CheckBox from 'components/CheckBox';
+import { MAIN_PATH } from 'constant';
+import ResponseCode from 'constant/response-code.enum';
+import messageType from 'types';
 
 // component: 인증 화면 컴포넌트 //
 function AuthServer() {
-
   // state: 페이지 상태 //
   const [view, setView] = useState<'sign-in' | 'sign-up'>('sign-in');
+
+  // function: 네비게이터 함수 //
+  const navigator = useNavigate();
 
   // component: 로그인 컴포넌트 //
   const SignInCard = () => {
@@ -25,6 +31,9 @@ function AuthServer() {
     // state: 이메일 value 상태 //
     const [email, setEmail] = useState<string>('');
 
+    // state: 이메일 오류 메시지 //
+    const [emailErrorMsg, setEmailErrorMsg] = useState<string | undefined>(undefined);
+
     // state: 비밀번호 value 상태 //
     const [password, setPassword] = useState<string>('');
 
@@ -36,28 +45,66 @@ function AuthServer() {
       'eye-light-off-icon',
     );
 
-    // state: 체크박스 value 상태 //
-    const [savedId, setSavedId] = useState<boolean>(false);
+    // state: 비밀번호 오류 메시지 //
+    const [pwErrorMsg, setPwErrorMsg] = useState<string | undefined>(undefined);
+
+    // state: 이메일 저장 value 상태 //
+    const [savedEmail, setSavedEmail] = useState<boolean>(false);
 
     // state: 에러 상태 //
     const [error, setError] = useState<boolean>(false);
 
     // function: sign in response 처리 함수//
     const signInResponse = (responseBody: SignInResponseDto | ResponseDto | null) => {
+      // comment: 서버가 안켜진 경우 또는 도메인 주소가 잘못된 경우 //
       if (!responseBody) {
-        alert('네트워크 상태를 확인해주세요.'); // comment: 서버가 안켜진 경우 또는 도메인 주소가 잘못된 경우 //
+        alert('네트워크 연결 상태를 확인해주세요!');
         return;
       }
 
-      const { code } = responseBody;
-      if (code === 'TSE') alert('서바 내 오류 입니다.');
-      if (code === 'SIF' || code === 'VF') setError(true);
-      if (code !== 'NFU') return;
+      const { code, message } = responseBody;
+
+      if (code === ResponseCode.TEMPORARY_SERVER_ERROR) {
+        alert(message);
+        return;
+      }
+
+      if (
+        code === ResponseCode.SIGN_IN_FAIL ||
+        code === ResponseCode.VALIDATION_FAIL ||
+        code === ResponseCode.NOT_FOUND_USER
+      ) {
+        setError(true);
+        return;
+      }
+
+      // uuid 와 role 을 세션 스토리지에 저장.
+      if(responseBody !== null){
+        if('uuid' in responseBody){
+          window.sessionStorage.setItem("uuid",responseBody.uuid);
+        }
+
+        if('role' in responseBody){
+          window.sessionStorage.setItem("role",responseBody.role);
+        }
+      }
+      
+      navigator(MAIN_PATH());
     };
+
+    // effect: 이메일 저장한 경우 cookie에 담긴 savedEmail 값을 확인하여 값을 넣어둔다. //
+    useEffect(() => {
+      const cookieChangeHandler = () => {
+        //
+      };
+
+      cookieChangeHandler();
+    }, []);
 
     // event-handler: 이메일 변경 이벤트 처리 //
     const onEmailChangeHandler = (event: ChangeEvent<HTMLInputElement>) => {
       setError(false);
+      setEmailErrorMsg(undefined);
       const { value } = event.target;
       setEmail(value);
     };
@@ -65,20 +112,30 @@ function AuthServer() {
     // event-handler: 비밀번호 변경 이벤트 처리 //
     const onPasswordChangeHandler = (event: ChangeEvent<HTMLInputElement>) => {
       setError(false);
+      setPwErrorMsg(undefined);
       const { value } = event.target;
       setPassword(value);
     };
 
     // event-handler: 로그인 버튼 click 이벤트 처리 //
     const onSignInButtonClickHandler = () => {
-      const requestBody: SignInRequestDto = { email, password, savedId };
+      const requestBody: SignInRequestDto = { email, password, savedEmail };
+
+      if (requestBody.email.trim() === '') {
+        setEmailErrorMsg('이메일을 입력바랍니다.');
+        return;
+      }
+
+      if (requestBody.password.trim() === '') {
+        setPwErrorMsg('비밀번호를 입력 바랍니다.');
+        return;
+      }
+
       signInRequest(requestBody).then(signInResponse);
     };
 
     // event-handler: 소셜 로그인 button click 이벤트 처리//
     const onSocialLoginClickHandler = () => {
-
-    // comment: kakao 인가번호 요청용 리소스 //
       const CLIENT_ID = process.env.REACT_APP_CLIENT_ID;
       const REDIRECT_URI = process.env.REACT_APP_REDIRECT_URI;
       window.location.href = `https://kauth.kakao.com/oauth/authorize?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=code`;
@@ -116,7 +173,8 @@ function AuthServer() {
     // event-handler: 아이디 저장 change 이벤트 처리 //
     const onCheckBoxChangeHandler = (event: ChangeEvent<HTMLInputElement>) => {
       const isChecked = event.target.checked;
-      setSavedId(isChecked);
+      setSavedEmail(isChecked);
+      console.log(isChecked);
     };
 
     // render: 로그인 컴포넌트 랜더링 //
@@ -131,6 +189,7 @@ function AuthServer() {
               type="text"
               value={email}
               error={error}
+              message={emailErrorMsg}
               onChange={onEmailChangeHandler}
               onKeyDown={onEmailKeyDownHandler}
             />
@@ -140,6 +199,7 @@ function AuthServer() {
               placeholder="password"
               type={passwordType}
               error={error}
+              message={pwErrorMsg}
               value={password}
               onChange={onPasswordChangeHandler}
               onIconClick={onPasswordIconClickHandler}
@@ -151,18 +211,20 @@ function AuthServer() {
             {error && (
               <div className="auth-sign-in-error-box">
                 <div className="auth-sign-in-error-message">
-                  {`이메일 주소 또는 비밀번호를 잘못 입력했습니다.
-                            입력하신 내용을 다시 확인해주세요.`}
+                  {`이메일 주소 또는 비밀번호를 잘못 입력했습니다.`}
+                  <br />
+                  {`입력하신 내용을 다시 확인해주세요.`}
                 </div>
               </div>
             )}
+            {!error && <div className="auth-sign-in-blank-box"></div>}
             <div className="auth-card-bottom-a">
               <div className="auth-card-save-email-box">
                 <CheckBox
                   id="savedEmail"
                   name="savedEmail"
                   label="이메일 저장"
-                  checked={savedId}
+                  checked={savedEmail}
                   onChange={onCheckBoxChangeHandler}
                 />
               </div>
@@ -174,7 +236,10 @@ function AuthServer() {
               <div className="auth-card-sign-in-btn" onClick={onSignInButtonClickHandler}>
                 {'Login'}
               </div>
-              <div className="icon auth-card-social-in-btn" onClick={onSocialLoginClickHandler}></div>
+              <div
+                className="icon auth-card-social-in-btn"
+                onClick={onSocialLoginClickHandler}
+              ></div>
             </div>
             <div className="auth-desc-box">
               <div className="auth-desc">
@@ -192,6 +257,7 @@ function AuthServer() {
 
   // component: 회원가입 컴포넌트 //
   const SignUpCard = () => {
+
     // comment: 요소 참조 상태 - key down 이벤트용 //
     // state: 이름 요소 참조 상태 //
     const nameRef = useRef<HTMLInputElement | null>(null);
@@ -218,101 +284,149 @@ function AuthServer() {
     // state: 이름 요소 상태 //
     const [name, setName] = useState<string>('');
 
+    // state: 이름 에러 상태 //
+    const [isNameError, setNameError] = useState<boolean>(false);
+
     // state: 닉네임 요소 상태 //
     const [nickname, setNickname] = useState<string>('');
+
+    // state: 닉네임 에러 상태 //
+    const [isNicknameError, setNicknameError] = useState<boolean>(false);
 
     // state: 전화번호 요소 상태 //
     const [phone, setPhone] = useState<string>('');
 
-    // state: 이메일 value 상태 //
+    // state: 전화번호 에러 상태 //
+    const [isPhoneError, setPhoneError] = useState<boolean>(false);
+
+    // state: 이메일 요소 상태 //
     const [email, setEmail] = useState<string>('');
 
-    // state: 비밀번호 value 상태 //
-    const [password, setPassword] = useState<string>('');
+    // state: 이메일 에러 상태 //
+    const [isEmailError, setEmailError] = useState<boolean>(false);
+
+    // state: 비밀번호 요소 상태 //
+    const [pw, setPw] = useState<string>('');
+
+    // state: 비밀번호 에러 상태 //
+    const [isPwError, setPwError] = useState<boolean>(false);
 
     // state: 비밀번호 확인 요소 상태 //
-    const [passwordCheck, setPasswordCheck] = useState<string>('');
+    const [pwRe, setPwRe] = useState<string>('');
+
+    // state: 비밀번호 확인 에러 상태 //
+    const [isPwReError, setPwReError] = useState<boolean>(false);
+
+    // state: 에러 메시지 //
+    const [message, setMessage] = useState<messageType>({   
+      name: "",
+      nickname: "",
+      phone: "",
+      email: "",
+      pw: "",
+      pwRe: "",
+      agree: "",
+    });
+
+    // state: 비밀번호 type 상태 //
+    const [pwType, setPwType] = useState<'text' | 'password'>('password');
+
+    // state: 비밀번호 확인 type 상태 //
+    const [pwReType, setPwReType] = useState<'text' | 'password'>('password');
 
     // state: 비밀번호 표시/숨김 아이콘 상태 //
-    const [passwordIcon, setPasswordIcon] = useState<'eye-light-off-icon' | 'eye-light-on-icon'>(
-      'eye-light-off-icon',
-    );
+    const [pwIcon, setPwIcon] = useState<'eye-light-off-icon' | 'eye-light-on-icon'>(
+      'eye-light-off-icon',);
 
-    // state: 비밀번호 표시/숨김 아이콘 상태 //
-    const [passwordCheckIcon, setPasswordCheckIcon] = useState<
-      'eye-light-off-icon' | 'eye-light-on-icon'
-    >('eye-light-off-icon');
+    // state: 비밀번호 확인 표시/숨김 아이콘 상태 //
+    const [pwReIcon, setPwReIcon] = useState<'eye-light-off-icon' | 'eye-light-on-icon'>(
+      'eye-light-off-icon',);
 
     // state: 개인정보 동의 요소 상태 //
     const [agree, setAgree] = useState<boolean>(false);
 
-    // state: 에러 상태 //
-    const [error, setError] = useState<boolean>(false);
+    // state: 닉네임 중복 여부 확인 상태 //
+    const [isDuplicated, setIsDuplicated] = useState<boolean>(false);
 
-    // state: 비밀번호 type 상태 //
-    const [passwordType, setPasswordType] = useState<'text' | 'password'>('password');
+    //state: 번호 인증 여부 확인 상태 //
+    const [isValidation, setValidationCheck] = useState<boolean>(false);
 
-    // state: 비밀번호 확인 type 상태 //
-    const [passwordCheckType, setPasswordCheckType] = useState<'text' | 'password'>('password');
-
-    // event-handler: 회원가입 버튼 click 이벤트 처리 //
-    const onSignUpButtonClickHandler = () => {
-      console.log('회원가입');
-    };
+    // state: 가입 가능 여부 상태 //
+    const [signUpEnable, setSignUpEnable] = useState<boolean>(false);
 
     // event-handler: 회원가입 링크 click 이벤트 처리 //
     const onSignInClickHandler = () => {
       setView('sign-in');
     };
 
-    
-
     // event-handler: 이름 변경 이벤트 처리 //
     const onNameChangeHandler = (event: ChangeEvent<HTMLInputElement>) => {
-      setError(false);
+      setNameError(false);
+      message.name = '';
       const { value } = event.target;
       setName(value);
     };
 
     // event-handler: 닉네임 변경 이벤트 처리 //
     const onNicknameChangeHandler = (event: ChangeEvent<HTMLInputElement>) => {
-      setError(false);
+      setNicknameError(false);
+      setIsDuplicated(false);
+      message.nickname = '';
       const { value } = event.target;
       setNickname(value);
     };
 
+    // effect: 닉네임 변경을 감지하여 중복 체크 //
+    useEffect(()=>{
+      const fetchData = async () => {
+        const response = await nicknameDupCheckRequest(nickname);
+        if(response){
+          if(response.code === ResponseCode.OK) return;
+          setIsDuplicated(true);
+        }
+      }
+
+      fetchData();
+
+    },[nickname]);
+
     // event-handler: 전화번호 변경 이벤트 처리 //
     const onPhoneChangeHandler = (event: ChangeEvent<HTMLInputElement>) => {
-      setError(false);
+      setPhoneError(false);
+      message.phone = '';
       const { value } = event.target;
       setPhone(value);
     };
 
     // event-handler: 이메일 변경 이벤트 처리 //
     const onEmailChangeHandler = (event: ChangeEvent<HTMLInputElement>) => {
-      setError(false);
+      setEmailError(false);
+      message.email = '';
       const { value } = event.target;
       setEmail(value);
     };
 
     // event-handler: 비밀번호 변경 이벤트 처리 //
     const onPasswordChangeHandler = (event: ChangeEvent<HTMLInputElement>) => {
-      setError(false);
+      setPwError(false);
+      message.pw = '';
       const { value } = event.target;
-      setPassword(value);
+      setPw(value);
     };
 
     // event-handler: 비밀번호 확인 변경 이벤트 처리 //
     const onPassworCheckChangeHandler = (event: ChangeEvent<HTMLInputElement>) => {
-      setError(false);
+      setPwReError(false);
+      message.pwRe = '';
       const { value } = event.target;
-      setPasswordCheck(value);
+      setPwRe(value);
     };
 
     // event-handler: 개인정보 제공 동의 change 이벤트 처리 //
     const onCheckBoxChangeHandler = (event: ChangeEvent<HTMLInputElement>) => {
       const isChecked = event.target.checked;
       setAgree(isChecked);
+      if(isChecked) message.agree = '';
     };
 
     // event-handler: 이름 input key down 이벤트 처리 //
@@ -363,40 +477,111 @@ function AuthServer() {
       onSignUpButtonClickHandler();
     };
 
-    // event-handler: 닉네임 중복 확인 click 이벤트 처리 //
-    const onNicknameClickHandler = async () => {
-      if (nickname.trim() === '') return;
-      const response = await nicknameDupCheckRequest(nickname);
-      console.log(response);
-
-      if (response?.status === '200') {
-        alert('사용 가능한 닉네임 입니다.');
-      } else {
-        alert('중복된 닉네임 입니다');
-      }
-    };
-
     // event-handler: 비밀번호 표시/숨김 아이콘 버튼 click 이벤트 처리 //
     const onPasswordIconClickHandler = () => {
-      if (passwordType === 'text') {
-        setPasswordType('password');
-        setPasswordIcon('eye-light-off-icon');
+      if (pwType === 'text') {
+        setPwType('password');
+        setPwIcon('eye-light-off-icon');
       } else {
-        setPasswordType('text');
-        setPasswordIcon('eye-light-on-icon');
+        setPwType('text');
+        setPwIcon('eye-light-on-icon');
       }
     };
 
     // event-handler: 비밀번호 확인 표시/숨김 아이콘 버튼 click 이벤트 처리 //
     const onPasswordCheckIconClickHandler = () => {
-      if (passwordCheckType === 'text') {
-        setPasswordCheckType('password');
-        setPasswordCheckIcon('eye-light-off-icon');
+      if (pwReType === 'text') {
+        setPwReType('password');
+        setPwReIcon('eye-light-off-icon');
       } else {
-        setPasswordCheckType('text');
-        setPasswordCheckIcon('eye-light-on-icon');
+        setPwReType('text');
+        setPwReIcon('eye-light-on-icon');
       }
     };
+
+    // event-handler: 번호 인증 버튼 click 이벤트 처리 //
+    const onValidationCheckClickHandler = async () => {
+      const responseBody = await phoneValidateRequest(phone);
+      if(responseBody){
+        if(responseBody.code === ResponseCode.OK){
+          setValidationCheck(true);
+        }
+      }
+    };
+
+    // function: 회원 가입 시 에러메시지 처리 기능 //
+    const signUpVfMsgResponse = (responseBody:string[])=> {
+
+        setMessage({ 
+          name: "",
+          nickname: "",
+          phone: "",
+          email: "",
+          pw: "",
+          pwRe: "",
+          agree: "",})
+
+        responseBody.map(e => {
+          const message = e.split(" : ");
+          setMessage((prev) => ( {...prev, [message[0]] : message[1]}));
+        })
+    }
+
+    // function: 회원 가입 후 응답처리 기능 //
+    const signUpResponse =(responseBody: ResponseDto | null) => {
+      // comment: 서버가 안켜진 경우 또는 도메인 주소가 잘못된 경우 //
+      if (!responseBody) {
+        alert('네트워크 연결 상태를 확인해주세요!');
+        return;
+      }
+
+      const { code, message } = responseBody
+
+      if(code === ResponseCode.USER_CREATED) {
+        alert(message);
+        navigator(MAIN_PATH());
+      }else{
+        alert(code);
+        return;
+      }
+    }
+
+    // event-handler: 가입하기 버튼 click 이벤트 처리 //
+    const onSignUpButtonClickHandler = async () => {
+      const requestBody: SignUpRequestDto = {
+        name,
+        nickname,
+        phone,
+        email,
+        pw,
+        pwRe,
+        agree,
+      };
+
+      if(pw !== pwRe){
+        setMessage(prev => ({...prev, pwRe: "비밀번호가 일치하지 않습니다"}));
+        return;
+      }
+
+      const response = await signUpRequest(requestBody);
+      if(response){
+        if(response.vfMessages) {
+          signUpVfMsgResponse(response.vfMessages); 
+          return;
+        }
+        signUpResponse(response);
+      }
+    };
+
+    // effect: 번호 인증 및 닉네임 중복 처리 완료 시 가입하기 버튼 활성화
+    useEffect(() => {
+      if(nickname !== '' && !isDuplicated){
+       setSignUpEnable(true);
+      }else{
+        setSignUpEnable(false);
+      }
+    },[isDuplicated, isValidation]);
+
 
     // render: 회원가입 컴포넌트 랜더링 //
     return (
@@ -405,39 +590,44 @@ function AuthServer() {
           <div className="auth-card-top">
             <InputBox
               ref={nameRef}
-              name="name"
+             name="name"
               type="text"
-              error={error}
+              error={isNameError}
               placeholder="이름"
               value={name}
               onChange={onNameChangeHandler}
               onKeyDown={onNameKeyDownHandler}
+              message={message.name}
             />
-            <div className="nickname-dup-check-box">
+            <div className="auth-sign-up-valid-box">
               <InputBox
                 ref={nicknameRef}
                 name="nickname"
                 type="text"
-                error={error}
+                error={isNicknameError}
                 placeholder="닉네임"
                 value={nickname}
                 onChange={onNicknameChangeHandler}
                 onKeyDown={onNicknameKeyDownHandler}
+                message={message.nickname}
               />
-              <ButtonBox label="중복 확인" type="button" onClick={onNicknameClickHandler} />
+              {!isDuplicated && nickname !== '' ?
+               (<p className='correct-message'>{'✅ 사용 가능'}</p>):<></>}
+              {isDuplicated && (<p className='error-message'>{'❌ 사용 불가'}</p>)}
             </div>
-            <div className="phone-verify-box">
+            <div className="auth-sign-up-valid-box">
               <InputBox
                 ref={phoneRef}
                 name="phone"
                 type="text"
-                error={error}
+                error={isPhoneError}
                 placeholder="휴대전화 번호"
                 value={phone}
                 onChange={onPhoneChangeHandler}
                 onKeyDown={onPhoneKeyDownHandler}
+                message={message.phone}
               />
-              <ButtonBox label="번호 인증" type="button" />
+              <ButtonBox isEnable={true} label="번호 인증" type="button" onClick={onValidationCheckClickHandler}/>
             </div>
             <InputBox
               ref={emailRef}
@@ -445,45 +635,49 @@ function AuthServer() {
               placeholder="이메일"
               type="text"
               value={email}
-              error={error}
+              error={isEmailError}
               onChange={onEmailChangeHandler}
               onKeyDown={onEmailKeyDownHandler}
+              message={message.email}
             />
             <InputBox
               ref={passwordRef}
               name="password"
               placeholder="비밀번호"
-              type={passwordType}
-              error={error}
-              value={password}
+              type={pwType}
+              error={isPwError}
+              value={pw}
               onChange={onPasswordChangeHandler}
               onIconClick={onPasswordIconClickHandler}
               onKeyDown={onPasswordKeyDownHandler}
-              icon={passwordIcon}
+              icon={pwIcon}
+              message={message.pw}
             />
             <InputBox
               ref={passwordCheckRef}
               name="passwordCheck"
               placeholder="비밀번호 확인"
-              type={passwordCheckType}
-              error={error}
-              value={passwordCheck}
+              type={pwReType}
+              error={isPwReError}
+              value={pwRe}
               onChange={onPassworCheckChangeHandler}
               onIconClick={onPasswordCheckIconClickHandler}
               onKeyDown={onPasswordCheckKeyDownHandler}
-              icon={passwordCheckIcon}
+              icon={pwReIcon}
+              message={message.pwRe}
             />
           </div>
           <div className="auth-card-bottom">
             <CheckBox
               id="agree"
-              label="개인정보 동의"
+              label="개인정보 제공 동의"
               name="agree"
               checked={agree}
               onChange={onCheckBoxChangeHandler}
               onKeyDown={onAgreeKeyDownHandler}
+              message={message.agree}
             />
-            <ButtonBox label={'가입하기'} type={'submit'} />
+            <ButtonBox isEnable={signUpEnable} label={'가입하기'} type={'button'} onClick={onSignUpButtonClickHandler} />
           </div>
           <div className="auth-desc-box">
             <div className="auth-desc">

--- a/front-server/src/pages/Authentication/style.css
+++ b/front-server/src/pages/Authentication/style.css
@@ -23,6 +23,14 @@
   background-color: rgb(255, 255, 255);
 }
 
+.auth-card-top {
+  margin: 10px;
+}
+
+.auth-card-bottom {
+  margin: 10px;
+}
+
 .auth-card-bottom-a {
   display: flex;
   justify-content: space-around;
@@ -97,4 +105,28 @@
   color: rgba(0, 0, 0, 1);
   font-weight: 550;
   cursor: pointer;
+}
+
+.auth-sign-in-error-box {
+  min-height: 38px;
+  color: rgba(255, 0, 0, 0.8);
+  font-size: 14px;
+}
+
+.auth-sign-in-blank-box {
+  min-height: 38px;
+  background-color: rgba(255, 255, 255, 0);
+}
+
+/* sign-up-card : 닉네임 & 번호 인증 */
+.auth-sign-up-valid-box {
+  display: flex;
+  align-items: center;
+}
+
+.auth-sign-up-valid-box > p{
+  margin: 5px;
+
+  font-size: 12px;
+  font-weight: 300;
 }

--- a/front-server/src/pages/Social/kakao/index.tsx
+++ b/front-server/src/pages/Social/kakao/index.tsx
@@ -1,21 +1,27 @@
 import { useEffect } from 'react';
-import { kakaoCallbackAuthCodeRequest } from "apis";
-import Loading from "components/Loading";
-import { useLocation } from "react-router-dom";
+import { kakaoCallbackAuthCodeRequest } from 'apis';
+import Loading from 'components/Loading';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { MAIN_PATH } from 'constant';
 
-const Social: React.FC = ()=>{
-    const location = useLocation();
-    const queryParams = new URLSearchParams(location.search);
-    const authCode = queryParams.get('code');
+const Social: React.FC = () => {
+  const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
+  const authCode = queryParams.get('code');
+  const error = queryParams.get('error');
 
-    // alert(`인가 코드 정상 발급! : [ ${authCode} ]`);
+  // function: 네비게이터 함수 //
+  const navigator = useNavigate();
 
-    useEffect(
-        ()=>{
-       kakaoCallbackAuthCodeRequest(authCode);
-    },[]);
-    
-    return(<Loading />);
+  // alert(`인가 코드 정상 발급! : [ ${authCode} ]`);
+  useEffect(() => {
+    if(authCode){kakaoCallbackAuthCodeRequest(authCode);} 
+    if(error){alert('카카오 로그인 실패하셨습니다.'); return;}
+    alert('로그인에 성공하셨습니다.');
+    navigator(MAIN_PATH());
+  }, []);
+
+  return <Loading />
 };
 
 export default Social;

--- a/front-server/src/pages/Test/index.tsx
+++ b/front-server/src/pages/Test/index.tsx
@@ -60,10 +60,10 @@ const CorsTest: React.FC = () => {
 
   return (
     <>
-      <ButtonBox label="not-cors" type="button" onClick={notCorsResponse}/>
-      <ButtonBox label='cors' type='button' onClick={corsResponse}/>
-      <ButtonBox label='not-proxy' type='button' onClick={notProxyResponse}/>
-      <ButtonBox label='proxy' type='button' onClick={proxyResponse}/>
+      <ButtonBox isEnable={true} label="not-cors" type="button" onClick={notCorsResponse} />
+      <ButtonBox isEnable={true} label="cors" type="button" onClick={corsResponse} />
+      <ButtonBox isEnable={true} label="not-proxy" type="button" onClick={notProxyResponse} />
+      <ButtonBox isEnable={true} label="proxy" type="button" onClick={proxyResponse} />
     </>
   );
 };

--- a/front-server/src/pages/board/post/Post.tsx
+++ b/front-server/src/pages/board/post/Post.tsx
@@ -7,22 +7,24 @@ function GetCategory() {
   const [category, setCategory] = useState<category[]>([]);
 
   useEffect(() => {
-    axios.get('http://localhost:8000/deal-service/api/v1/categories').then((response)=> {
-      console.log(response.data.categories);
-      const categoryArray = Object.values(response.data.categories) as category[];
-      setCategory(categoryArray);
-    })
-    .catch((error) => {
-      console.error('Error fetching categories:', error);
-    });
+    axios
+      .get('http://localhost:8000/deal-service/api/v1/categories')
+      .then((response) => {
+        console.log(response.data.categories);
+        const categoryArray = Object.values(response.data.categories) as category[];
+        setCategory(categoryArray);
+      })
+      .catch((error) => {
+        console.error('Error fetching categories:', error);
+      });
   }, []);
 
-  console.log(category)
+  console.log(category);
 
   type category = {
     id: number;
-    value: string,
-  }
+    value: string;
+  };
 
   const categories = category.map((item: category, i) => (
     <option key={i} value={item.id}>
@@ -34,7 +36,6 @@ function GetCategory() {
 }
 
 function UploadBoard() {
-
   const [imageFile, setImageFile] = useState<File | undefined>(undefined);
   const categories = GetCategory();
   const [title, setTitle] = useState('');
@@ -45,75 +46,80 @@ function UploadBoard() {
 
   const body = {
     title: title,
-    categoryId : categoryId,
+    categoryId: categoryId,
     content: detail,
     price: price,
     link: link,
+  };
+
+  const HandleSubmit = async (body: string) => {
+    const response = await axios.post('http://localhost:8888/api/v1/post', body);
+    const postId = response.data.id;
+
+    // 2번 API 호출: 이미지 업로드
+    if (imageFile) {
+      const formData = new FormData();
+      formData.append('postId', postId);
+      formData.append('file', imageFile);
+
+      await axios.post('http://localhost:8888/api/v1/upload', formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      });
     }
+  };
 
-    const HandleSubmit = async(body : string) => {
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const fileInput = e.target as HTMLInputElement;
+    const selectedFile = fileInput.files?.[0];
 
-        const response = await axios.post('http://localhost:8888/api/v1/post', body);
-        const postId = response.data.id;
-      
-        // 2번 API 호출: 이미지 업로드
-        if (imageFile) {
-          const formData = new FormData();
-          formData.append('postId', postId);
-          formData.append('file', imageFile);
-      
-          await axios.post('http://localhost:8888/api/v1/upload', formData, {
-            headers: {
-              'Content-Type': 'multipart/form-data',
-            },
-          });
-        }
-        
+    if (selectedFile) {
+      setImageFile(selectedFile);
     }
+  };
 
-    const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const fileInput = e.target as HTMLInputElement;
-        const selectedFile = fileInput.files?.[0];
-    
-        if (selectedFile) {
-          setImageFile(selectedFile);
-        }
-      };
-
-  return (<>
-    <div className="post-view-wrapper">
+  return (
+    <>
+      <div className="post-view-wrapper">
         {/* <form onSubmit={HandleSubmit}> */}
-        <div className="post-view-row"> 
-        <label>이미지</label>
-        <input type="file" onChange={handleImageChange} />
+        <div className="post-view-row">
+          <label>이미지</label>
+          <input type="file" onChange={handleImageChange} />
         </div>
         <div className="post-view-row">
-        <label>제목</label>
-        <input type="text" value={title} onChange={(e) => setTitle(e.target.value)}></input>
-    </div>
-    <div className="post-view-row">
-        <label>카테고리 선택</label>
-        <select onChange={(event) => setCategoryId(parseInt(event.target.value))}>
-          {categories}
-        </select>
-    </div>
-    <div className="post-view-row">
-        <label>가격</label>
-        <input type="text" value={price} onChange={(e) => setPrice(e.target.value)}></input>
-    </div>
-    <div className="post-view-row">
-        <label>내용</label>
-        <input type="text" value={detail} onChange={(e) => setDetail(e.target.value)}></input>
-    </div>
-    <div className="post-view-row">
-        <label>오픈 카카오톡 채팅 링크</label>
-        <input type="text" value={link} onChange={(e) => setLink(e.target.value)}></input>
-    </div>
+          <label>제목</label>
+          <input type="text" value={title} onChange={(e) => setTitle(e.target.value)}></input>
+        </div>
+        <div className="post-view-row">
+          <label>카테고리 선택</label>
+          <select onChange={(event) => setCategoryId(parseInt(event.target.value))}>
+            {categories}
+          </select>
+        </div>
+        <div className="post-view-row">
+          <label>가격</label>
+          <input type="text" value={price} onChange={(e) => setPrice(e.target.value)}></input>
+        </div>
+        <div className="post-view-row">
+          <label>내용</label>
+          <input type="text" value={detail} onChange={(e) => setDetail(e.target.value)}></input>
+        </div>
+        <div className="post-view-row">
+          <label>오픈 카카오톡 채팅 링크</label>
+          <input type="text" value={link} onChange={(e) => setLink(e.target.value)}></input>
+        </div>
         {/* </form> */}
-    
-    <button className="post-view-go-list-btn" onClick={() => HandleSubmit(JSON.stringify(body))}>등록</button>
-    </div>
-    </>)
+
+        <button
+          className="post-view-go-list-btn"
+          onClick={() => HandleSubmit(JSON.stringify(body))}
+        >
+          등록
+        </button>
+      </div>
+    </>
+  );
 }
-  
+
 export default UploadBoard;

--- a/front-server/src/setupProxy.js
+++ b/front-server/src/setupProxy.js
@@ -2,12 +2,40 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
-module.exports = function(app) {
+module.exports = function (app) {
   app.use(
-    '/api', //proxy가 필요한 path parameter
+    '/auth-server',
     createProxyMiddleware({
+      //proxy가 필요한 path parameter
       target: 'http://localhost:8000', //타겟이 되는 api url
       changeOrigin: true, // 서버 구성에 따른 호스트 헤더 변경 여부 설정
-    })
+    }),
+  );
+
+  app.use(
+    '/user-service',
+    createProxyMiddleware({
+      //proxy가 필요한 path parameter
+      target: 'http://localhost:8000', //타겟이 되는 api url
+      changeOrigin: true, // 서버 구성에 따른 호스트 헤더 변경 여부 설정
+    }),
+  );
+
+  app.use(
+    '/deal-service',
+    createProxyMiddleware({
+      //proxy가 필요한 path parameter
+      target: 'http://localhost:8000', //타겟이 되는 api url
+      changeOrigin: true, // 서버 구성에 따른 호스트 헤더 변경 여부 설정
+    }),
+  );
+
+  app.use(
+    '/admin-service',
+    createProxyMiddleware({
+      //proxy가 필요한 path parameter
+      target: 'http://localhost:8000', //타겟이 되는 api url
+      changeOrigin: true, // 서버 구성에 따른 호스트 헤더 변경 여부 설정
+    }),
   );
 };

--- a/front-server/src/types/index.ts
+++ b/front-server/src/types/index.ts
@@ -1,0 +1,11 @@
+type messageType = {
+    name: string;
+    nickname: string;
+    phone: string;
+    email: string;
+    pw: string;
+    pwRe: string;
+    agree: string;
+}
+
+export default messageType;

--- a/user-service/src/main/java/com/wesell/userservice/controller/DupNicknameCheckController.java
+++ b/user-service/src/main/java/com/wesell/userservice/controller/DupNicknameCheckController.java
@@ -1,0 +1,26 @@
+package com.wesell.userservice.controller;
+
+import com.wesell.userservice.service.DupNicknameCheckService;
+import com.wesell.userservice.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("api/v1")
+@Log4j2
+public class DupNicknameCheckController {
+
+    private final DupNicknameCheckService service;
+
+    @GetMapping("/dup-check")
+    public ResponseEntity<Void> checkNickname(@RequestParam("nickname") String nickname){
+        service.checkNickname(nickname);
+        return ResponseEntity.ok(null);
+    }
+}

--- a/user-service/src/main/java/com/wesell/userservice/domain/repository/NicknameCheckRepository.java
+++ b/user-service/src/main/java/com/wesell/userservice/domain/repository/NicknameCheckRepository.java
@@ -1,0 +1,8 @@
+package com.wesell.userservice.domain.repository;
+
+import com.wesell.userservice.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NicknameCheckRepository extends JpaRepository<User,String> {
+    boolean existsUserByNickname(String nickname);
+}

--- a/user-service/src/main/java/com/wesell/userservice/service/DupNicknameCheckService.java
+++ b/user-service/src/main/java/com/wesell/userservice/service/DupNicknameCheckService.java
@@ -1,0 +1,15 @@
+package com.wesell.userservice.service;
+
+import com.wesell.userservice.domain.repository.NicknameCheckRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DupNicknameCheckService {
+    private final NicknameCheckRepository repository;
+
+    public void checkNickname(String nickname){
+        if(repository.existsUserByNickname(nickname)) throw new RuntimeException("닉네임 중복!");
+    }
+}


### PR DESCRIPTION
###  🎆 회원가입 & 로그인 api 통신 테스트 및 일부 로직 수정
🎇 오타 및 코드 공백 최소화
- 이전 merge 중 발생한 CONFLICT 사항 수정 중 일부 오타가 남아있어 수정함

🎇프록시 설정으로 변경된 경로 반영을 위한 수정 작업함

🎇front-server 측에서 받을 응답 json 데이터의 양식을 통일하기 위해 ResponseDto 및 일부 코드 수정함

🎇CORS 정책 관련 요청 오류 해결을 위한 설정 부분 수정함
- gateway 측에서 설정한 부분만 사용할 경우, 브라우저 측에서 쿠키가 저장되지 않는 현상 발생.
- 정확한 원인은 아직 확인하지 못하였으며, front-server 측에서 프록시 서버를 사용한 설정 시에는 정상적으로 쿠키 저장됨.
- 추후 정확한 원인 알아볼 예정입니다.

🎇 프론트 소셜 로그인 관련 로직 추가
- 소셜 로그인 후 응답 처리하기 위한 로직 추가.
- 성공 시 메인 페이지로 이동.

🎇 프론트 회원가입 시 닉네임 중복 로직 추가
- 닉네임 상태 변화를  감지하여 중복내용 조회함.

🎇 프론트 번호 인증 로직 추가
- 휴대폰 번호 인증 url과 api 통신할 수 있도록 로직 구현함.