### PR TITLE
ref: RTR(Refresh Token Rotation) 방식 도입

### DIFF
--- a/authentication-server/build.gradle
+++ b/authentication-server/build.gradle
@@ -63,6 +63,8 @@ dependencies {
 	// OAuth 2.0
 
 	// Test 코드
+	implementation 'com.h2database:h2'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AuthController.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AuthController.java
@@ -7,8 +7,6 @@ import com.wesell.authenticationserver.controller.response.ResponseDto;
 import com.wesell.authenticationserver.service.dto.oauth.KakaoAccount;
 import com.wesell.authenticationserver.service.dto.response.SignInSuccessResponseDto;
 import com.wesell.authenticationserver.global.util.CustomCookie;
-import com.wesell.authenticationserver.controller.response.CustomException;
-import com.wesell.authenticationserver.controller.response.ErrorCode;
 import com.wesell.authenticationserver.controller.response.SuccessCode;
 import com.wesell.authenticationserver.service.AuthUserService;
 import com.wesell.authenticationserver.service.oauth.KakaoService;
@@ -56,7 +54,8 @@ public class AuthController {
         GeneratedTokenDto generatedTokenDto = authUserService.login(requestDto);
 
         log.debug("AuthController - 액세스 토큰 쿠키 생성");
-        ResponseCookie accessTokenCookie = cookieUtil.createTokenCookie(generatedTokenDto.getAccessToken());
+        ResponseCookie accessTokenCookie = cookieUtil.createAccessTokenCookie(generatedTokenDto.getAccessToken());
+        ResponseCookie refreshTokenCookie = cookieUtil.createRefreshTokenCookie(generatedTokenDto.getRefreshToken());
 
         log.debug("AuthController - 이메일 저장 기능");
         ResponseCookie savedEmailCookie;
@@ -68,8 +67,8 @@ public class AuthController {
 
         return ResponseEntity
                 .status(SuccessCode.OK.getStatus())
-                .header(HttpHeaders.AUTHORIZATION,"Bearer "+generatedTokenDto.getRefreshToken())
                 .header(HttpHeaders.SET_COOKIE,accessTokenCookie.toString())
+                .header(HttpHeaders.SET_COOKIE,refreshTokenCookie.toString())
                 .header(HttpHeaders.SET_COOKIE,savedEmailCookie.toString())
                 .body(new SignInSuccessResponseDto(generatedTokenDto.getUuid(), generatedTokenDto.getRole()));
     }
@@ -84,47 +83,49 @@ public class AuthController {
         log.debug("소셜 로그인 - 회원 확인 및 회원 가입");
         GeneratedTokenDto generatedTokenDto = authUserService.findOrCreateUser(kakaoAccount);
 
-        log.debug("AuthController - 액세스 토큰 쿠키 생성");
-        ResponseCookie accessTokenCookie = cookieUtil.createTokenCookie(generatedTokenDto.getAccessToken());
+        log.debug("AuthController - 쿠키 생성");
+        ResponseCookie accessTokenCookie = cookieUtil.createAccessTokenCookie(generatedTokenDto.getAccessToken());
+        ResponseCookie refreshTokenCookie = cookieUtil.createRefreshTokenCookie(generatedTokenDto.getRefreshToken());
 
         return ResponseEntity
                 .status(SuccessCode.OK.getStatus())
-                .header(HttpHeaders.AUTHORIZATION,"Bearer "+generatedTokenDto.getRefreshToken())
                 .header(HttpHeaders.SET_COOKIE,accessTokenCookie.toString())
+                .header(HttpHeaders.SET_COOKIE,refreshTokenCookie.toString())
                 .body(new SignInSuccessResponseDto(generatedTokenDto.getUuid(), generatedTokenDto.getRole()));
     }
 
     // 만료된 토큰 갱신
-    @PostMapping("refresh")
-    public ResponseEntity<Void> refresh(
+    @GetMapping("refresh")
+    public ResponseEntity<?> refresh(
             @CookieValue(name = "access-token") String accessToken,
-            @RequestHeader(value = "Authorization") String refreshToken
+            @CookieValue(name = "refresh-token") String refreshToken
             ){
-        log.debug("AuthController - 토큰 갱신");
-        String newToken = authUserService.refreshToken(refreshToken,accessToken);
-        ResponseCookie newTokenCookie = cookieUtil.createTokenCookie(newToken);
 
-        if(newTokenCookie.getValue().isEmpty()) {
-            throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
-        }
+        log.debug("AuthController - 토큰 갱신");
+        GeneratedTokenDto generatedTokenDto = authUserService.refreshToken(refreshToken,accessToken);
+
+        ResponseCookie newAccessTokenCookie = cookieUtil.createAccessTokenCookie(generatedTokenDto.getAccessToken());
+        ResponseCookie newRefreshTokenCookie = cookieUtil.createRefreshTokenCookie(generatedTokenDto.getRefreshToken());
 
         return ResponseEntity
                 .status(SuccessCode.OK.getStatus())
-                .header(HttpHeaders.SET_COOKIE,newTokenCookie.toString())
-                .body(null);
-
+                .header(HttpHeaders.SET_COOKIE,newAccessTokenCookie.toString())
+                .header(HttpHeaders.SET_COOKIE,newRefreshTokenCookie.toString())
+                .body(ResponseDto.of(SuccessCode.OK));
     }
 
     // 로그아웃
     @PostMapping("logout")
-    public ResponseEntity<Void> logout(){
-
-        ResponseCookie deleteAccessToken = cookieUtil.deleteTokenCookie();
+    public ResponseEntity<?> logout(){
+        log.debug("AuthController - 로그아웃");
+        ResponseCookie deleteAccessToken = cookieUtil.deleteAccessTokenCookie();
+        ResponseCookie deleteRefreshToken = cookieUtil.deleteRefreshTokenCookie();
 
         return ResponseEntity
                 .status(SuccessCode.OK.getStatus())
                 .header(HttpHeaders.SET_COOKIE,deleteAccessToken.toString())
-                .body(null);
+                .header(HttpHeaders.SET_COOKIE, deleteRefreshToken.toString())
+                .body(ResponseDto.of(SuccessCode.OK));
     }
 
 }

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/controller/CertificatePhoneController.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/controller/CertificatePhoneController.java
@@ -2,15 +2,10 @@ package com.wesell.authenticationserver.controller;
 
 import com.wesell.authenticationserver.global.util.SmsUtil;
 import lombok.RequiredArgsConstructor;
-import net.nurigo.sdk.message.model.Message;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-<<<<<<< HEAD
-@RequestMapping("api/v1")
-=======
->>>>>>> dev
 @RequiredArgsConstructor
 @RequestMapping("api/v1")
 public class CertificatePhoneController {
@@ -28,5 +23,4 @@ public class CertificatePhoneController {
 
         return ResponseEntity.ok(phoneNumber);
     }
-
 }

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/controller/response/ErrorCode.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/controller/response/ErrorCode.java
@@ -20,13 +20,12 @@ public enum ErrorCode {
      */
     // Validation Fail
     VALIDATION_FAIL(HttpStatus.BAD_REQUEST,"VF","유효성 검증 실패하였습니다."),
-    // Sign-In-Fail
-    SIGN_IN_FAIL(HttpStatus.BAD_REQUEST,"SIF","로그인에 실패하였습니다."),
     // Forced-Deleted-User
     FORCED_DELETED_USER(HttpStatus.FORBIDDEN, "FDU","접근이 제한되었습니다."),
     // Not-Found-User
-    NOT_FOUND_USER(HttpStatus.BAD_REQUEST,"NFU","등록 되지 않은 회원입니다."),
-
+    NOT_FOUND_USER(HttpStatus.BAD_REQUEST,"NFU","가입 되지 않은 회원입니다."),
+    // Password-Not-Correct
+    NOT_CORRECT_PASSWORD(HttpStatus.BAD_REQUEST,"NCP","비밀번호가 일치하지 않습니다."),
 
     /**
      * token
@@ -36,7 +35,12 @@ public enum ErrorCode {
     // Refresh-token Invalid
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED,"IRT","유효 하지 않은 Refresh token 입니다."),
     // Expired Jwt
-    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED,"EAT","JWT 만료 기한이 지났습니다.");
+    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED,"EAT","JWT 만료 기한이 지났습니다."),
+
+    /**
+     * feign 관련 오류
+     */
+    USER_SERVICE_FEIGN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"USFE","유저 서비스로 Feign 요청 시 오류 발생");
 
 
     private final HttpStatus status; // 상태코드(숫자)

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/CustomCookie.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/CustomCookie.java
@@ -7,13 +7,22 @@ import org.springframework.stereotype.Component;
 @Component
 public class CustomCookie {
 
-    // 쿠키 생성
-    public ResponseCookie createTokenCookie(String token){
+    // access-token 쿠키 생성
+    public ResponseCookie createAccessTokenCookie(String token){
 
         return ResponseCookie.from("access-token", token)
                 .path("/")
                 .httpOnly(true)
                 .maxAge(60*60)
+                .build();
+    }
+
+    // refresh-token 쿠키 생성
+    public ResponseCookie createRefreshTokenCookie(String refreshToken){
+        return ResponseCookie.from("refresh-token",refreshToken)
+                .path("/")
+                .httpOnly(true)
+                .maxAge(60*60*24)
                 .build();
     }
 
@@ -24,12 +33,19 @@ public class CustomCookie {
                 .path("/")
                 .maxAge(60 * 60 *24)
                 .build();
-
     }
 
     // 쿠키 무효화
-    public ResponseCookie deleteTokenCookie(){
+    public ResponseCookie deleteAccessTokenCookie(){
         return ResponseCookie.from("access-token")
+                .path("/")
+                .httpOnly(true)
+                .maxAge(0)
+                .build();
+    }
+
+    public ResponseCookie deleteRefreshTokenCookie(){
+        return ResponseCookie.from("refresh-token")
                 .path("/")
                 .httpOnly(true)
                 .maxAge(0)

--- a/authentication-server/src/main/resources/application-test.yml
+++ b/authentication-server/src/main/resources/application-test.yml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        check_nullability: true
+    show_sql: true

--- a/authentication-server/src/test/java/com/wesell/authenticationserver/service/CookieUtilTest.java
+++ b/authentication-server/src/test/java/com/wesell/authenticationserver/service/CookieUtilTest.java
@@ -1,0 +1,32 @@
+package com.wesell.authenticationserver.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseCookie;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
+public class CookieUtilTest {
+
+    private ResponseCookie cookie;
+
+    @BeforeEach
+    public void setUpTest(){
+        System.out.println("## BeforeEach! ##");
+
+        cookie = ResponseCookie.from("access-token", "a.b.c")
+                .path("/")
+                .httpOnly(true)
+                .maxAge(60*60)
+                .build();
+    }
+
+    @Test
+    @DisplayName("Test : Cookie 정보 확인하기")
+    public void checkCookie(){
+//        cookie = null;
+
+        System.out.println(cookie.getValue().isBlank());
+    }
+}

--- a/authentication-server/src/test/java/com/wesell/authenticationserver/service/TokenProviderTest.java
+++ b/authentication-server/src/test/java/com/wesell/authenticationserver/service/TokenProviderTest.java
@@ -1,0 +1,112 @@
+package com.wesell.authenticationserver.service;
+
+import com.wesell.authenticationserver.controller.dto.GeneratedTokenDto;
+import com.wesell.authenticationserver.domain.entity.AuthUser;
+import com.wesell.authenticationserver.domain.enum_.Role;
+import io.jsonwebtoken.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+import java.time.Duration;
+import java.util.Date;
+import java.util.UUID;
+
+@TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
+public class TokenProviderTest {
+
+    private GeneratedTokenDto tokenDto;
+
+    @BeforeEach
+    public void setUpTest(){
+        System.out.println("## BeforeEach! ##");
+
+        AuthUser authUser = AuthUser.builder()
+                .uuid("1")
+                .email("a@test.com")
+                .password("1")
+                .role(Role.USER)
+                .isDeleted(false)
+                .isForced(false)
+                .build();
+
+        System.out.println("## AuthUser 생성하기 ##");
+
+        Date now = new Date();
+        String sectionId = UUID.randomUUID().toString();
+
+        // 기한 만료된 token 생성 로직
+        String accessToken = Jwts.builder()
+                .setHeaderParam(Header.TYPE,Header.JWT_TYPE)
+                .setHeaderParam("alg","HS256")
+                .setHeaderParam("sectionId", sectionId)
+                .setSubject(authUser.getUuid())
+                .claim("role",authUser.getRole())
+                .setIssuer("issuer")
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + Duration.ofSeconds(1L).toMillis()))
+                .signWith(SignatureAlgorithm.HS256, "secret")
+                .compact();
+
+        String refreshToken = Jwts.builder()
+                .setHeaderParam(Header.TYPE,Header.JWT_TYPE)
+                .setHeaderParam("alg","HS256")
+                .setHeaderParam("sectionId", sectionId)
+                .setSubject(authUser.getUuid())
+                .claim("role",authUser.getRole())
+                .setIssuer("issuer")
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + Duration.ofHours(1L).toMillis()))
+                .signWith(SignatureAlgorithm.HS256, "secret")
+                .compact();
+
+        tokenDto = new GeneratedTokenDto("1","USER",accessToken,refreshToken);
+    }
+
+    @Test
+    @DisplayName("Test : 토큰 파싱 테스트")
+    public void accessTokenValidate(){
+        //given
+        String accessToken = tokenDto.getAccessToken();
+        String result = "";
+
+        //when
+        try {
+            Claims claims = Jwts.parser()
+                    .setSigningKey("secret")
+                    .requireIssuer("issuer")
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+            System.out.println(claims.get("sectionId"));
+            result += "+";
+        }catch(ExpiredJwtException ex){
+            result += "-";
+        }catch(Exception e){
+            result += "_";
+        }
+
+        //then
+        Assertions.assertEquals("-",result);
+        System.out.println("테스트 결과 : "+ result);
+    }
+
+    @Test
+    @DisplayName("Test : token에서 sectionId 추출하기")
+    public void getSectionId(){
+        //given
+        String accessToken = tokenDto.getAccessToken();
+        String refreshToken = tokenDto.getRefreshToken();
+        String result = "";
+
+        //when
+        String refreshHeaderParam = refreshToken.split("\\.")[0];
+        if(refreshHeaderParam.equals(accessToken.split("\\.")[0])){
+            result += "-";
+        }
+
+        //then
+        Assertions.assertEquals("-",result);
+    }
+
+}


### PR DESCRIPTION
🎆 RTR 방식 도입
- access-token 재발급 시, access-token 만료 여부 재확인 코드 추가.
- RTR 방식에 따라, refresh-token을 사용하여 access-token 재발급을 위한 일회용 토큰으로 사용.
- 만료된 access-token과 refresh-token 간의 연관관계를 나타내기 위해 헤더에 uuid 랜덤으로 생성하여, 토큰 생성 시마다 대입되도록 구현함.

🎆 Test code 작성
- jwt 토큰 만료 시, 실제 ExpiredJwtException 발생 여부 확인.

🎆 토큰 탈취에 대한 문제점 확인 및 리팩토링 예정
- access-token 탈취 시를 대비한 Redis black-list 방식 도입 예정.
- Redis 연동 예정.
