### PR TITLE
fix: front 측 access-token 재발급 로직 구현

### DIFF
--- a/apigateway-server/src/main/java/com/wesell/apigatewayserver/global/config/ReactiveSecurityConfig.java
+++ b/apigateway-server/src/main/java/com/wesell/apigatewayserver/global/config/ReactiveSecurityConfig.java
@@ -45,7 +45,8 @@ public class ReactiveSecurityConfig {
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer(){
         return web -> web.ignoring().requestMatchers("/v2/api-docs"
-                ,"/swagger-resources/**","/swagger-ui.html","/swagger/**");
+                ,"/swagger-resources/**","/swagger-ui.html","/swagger/**",
+                "/auth-server/api/v1/refresh");
     }
 
     @Bean

--- a/apigateway-server/src/main/java/com/wesell/apigatewayserver/global/token/TokenProvider.java
+++ b/apigateway-server/src/main/java/com/wesell/apigatewayserver/global/token/TokenProvider.java
@@ -43,7 +43,7 @@ public class TokenProvider {
             throw new CustomException(ErrorCode.INVALID_ACCESS_TOKEN);
         }catch (ExpiredJwtException e) {
             log.error("JWT token is expired: {}", e.getMessage());
-            throw new CustomException(ErrorCode.INVALID_ACCESS_TOKEN);
+            throw new CustomException(ErrorCode.EXPIRED_ACCESS_TOKEN);
         }catch(UnsupportedJwtException e) {
             log.error("JWT token is unsupported: {}", e.getMessage());
             throw new CustomException(ErrorCode.INVALID_ACCESS_TOKEN);

--- a/authentication-server/.gitignore
+++ b/authentication-server/.gitignore
@@ -37,5 +37,4 @@ out/
 .vscode/
 
 ### 민감정보 ###
-application-db.yml
-application-secret.yml
+application-local.yml

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AuthController.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AuthController.java
@@ -115,7 +115,7 @@ public class AuthController {
     }
 
     // 로그아웃
-    @PostMapping("logout")
+    @GetMapping("logout")
     public ResponseEntity<?> logout(){
         log.debug("AuthController - 로그아웃");
         ResponseCookie deleteAccessToken = cookieUtil.deleteAccessTokenCookie();

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/CustomCookie.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/global/util/CustomCookie.java
@@ -13,7 +13,7 @@ public class CustomCookie {
         return ResponseCookie.from("access-token", token)
                 .path("/")
                 .httpOnly(true)
-                .maxAge(60*60)
+                .maxAge(60*60+(60*30))
                 .build();
     }
 
@@ -22,7 +22,7 @@ public class CustomCookie {
         return ResponseCookie.from("refresh-token",refreshToken)
                 .path("/")
                 .httpOnly(true)
-                .maxAge(60*60*24)
+                .maxAge(60*60*24+(60*30))
                 .build();
     }
 

--- a/authentication-server/src/main/resources/application.yml
+++ b/authentication-server/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
     show_sql: true
 
   profiles:
-    active: db
+    active: local
 
 eureka:
   instance:
@@ -35,3 +35,9 @@ springdoc:
     disable-swagger-default-url: true
     display-request-duration: true
     operations-sorter: alpha
+
+token:
+  access-expired-time: ${access-expired}
+  refresh-expired-time: ${refresh-expired}
+  secret-key: ${secret-key}
+  issuer: ${issuer}

--- a/config-server/src/main/resources/application.yml
+++ b/config-server/src/main/resources/application.yml
@@ -8,4 +8,4 @@ spring:
         git:
           uri: https://github.com/playdata-final-project-team/Config.git
           username: ENC(cW5SlvBaWmiP1+VKyAf+cTGIHqEjDF5WGvhV9opSnYE=)
-          password: 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
+          password: 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

--- a/front-server/src/apis/index.ts
+++ b/front-server/src/apis/index.ts
@@ -2,9 +2,11 @@ import axios from 'axios';
 import { SignInRequestDto, SignUpRequestDto } from './request/auth';
 import { SignInResponseDto } from './response/auth';
 import { ResponseDto } from './response';
+import ResponseCode from 'constant/response-code.enum';
 
 const SIGN_IN_URL = () => '/auth-server/api/v1/sign-in';
 const SIGN_UP_URL = () => '/auth-server/api/v1/sign-up';
+const LOGOUT_URL = () => '/auth-server/api/v1/logout';
 const NICKNAME_CHECK_URL = () => '/user-service/api/v1/dup-check';
 const PHONE_CHECK_URL = () => '/auth-service/api/v1/phone/validate';
 const KAKAO_CALLBACK_URL = () => '/auth-server/api/v1/kakao/auth-code';
@@ -12,7 +14,6 @@ const REFRESH_TOKEN_URL = () => '/auth-server/api/v1/refresh';
 
 export const signInRequest = async (requestBody: SignInRequestDto) => {
   try {
-    console.log(requestBody);
     const response = await axios.post(SIGN_IN_URL(), requestBody);
     const responseBody: SignInResponseDto = response.data;
     return responseBody;
@@ -93,3 +94,44 @@ export const refreshTokenRequest = async () =>{
     return responseBody;
   }
 };
+
+export const logoutRequest = async () => {
+  try{
+    const response = await axios.get(LOGOUT_URL());
+    const responseBody: ResponseDto = response.data;
+    return responseBody;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }catch(error : any){
+    if(!error.response) return null;
+    const responseBody: ResponseDto = error.response.data;
+    return responseBody;
+  }
+}
+
+axios.interceptors.response.use(
+    (res) => res,
+    async (err) => {
+
+      const {config, response: {status}} = err;
+
+      if(config.url === REFRESH_TOKEN_URL || status !== 401 || config.sent){
+        return Promise.reject(err);
+      }
+
+      config.sent = true;
+      const responseBody : ResponseDto | null = await refreshTokenRequest();
+
+      if (!responseBody) {
+        alert('네트워크 연결 상태를 확인해주세요!');
+        return;
+      }
+
+      if(responseBody.code === ResponseCode.INVALID_REFRESH_TOKEN ||
+        responseBody.code === ResponseCode.EXPIRED_ACCESS_TOKEN){
+          logoutRequest();
+          window.location.href=`http://localhost:3000/auth`;// 로그인 페이지로 이동
+      }
+
+      return axios(config); // 재요청
+    }
+);


### PR DESCRIPTION
🎆 access-token 재발급 로직
- 401 오류 응답 시, 토큰 재발급 요청
- 재발급 성공 시 이전 요청을 재요청하여 해당 페이지가 정상적으로 응답나오도록 구현

🎆 페이지 부재로 테스트 불가..
- 토큰 만료 후 다른 페이지로 요청 시, access-token 및 refresh-token이 재발급 되는지 확인하기 위한 테스트 불가.
- 프론트 페이지 구현 후 테스트 예정임.