### PR TITLE
feat: 알림 서비스 구현

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectRootManager">
     <output url="file://$PROJECT_DIR$/out" />

--- a/front-server/.gitignore
+++ b/front-server/.gitignore
@@ -24,3 +24,6 @@ yarn-error.log*
 
 # 민감정보
 .env
+
+# 구독 유저 정보
+data.json

--- a/front-server/.idea/misc.xml
+++ b/front-server/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectRootManager">
     <output url="file://$PROJECT_DIR$/out" />

--- a/front-server/.idea/workspace.xml
+++ b/front-server/.idea/workspace.xml
@@ -4,17 +4,7 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="92f63182-175e-4fe9-8f41-34293aef690c" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.gitignore" beforeDir="false" afterPath="$PROJECT_DIR$/.gitignore" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/misc.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/misc.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/package.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/App.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/App.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/constant/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/constant/index.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/setupProxy.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/setupProxy.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/types/interface/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/types/interface/index.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/tsconfig.json" beforeDir="false" afterPath="$PROJECT_DIR$/tsconfig.json" afterDir="false" />
-    </list>
+    <list default="true" id="92f63182-175e-4fe9-8f41-34293aef690c" name="Changes" comment="feat: 알림 서비스 구현" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -33,22 +23,22 @@
   <component name="ProjectViewState">
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "WebServerToolWindowFactoryState": "false",
-    "git-widget-placeholder": "dev",
-    "last_opened_file_path": "D:/teamPRJ/fixwesell/Wesell/front-server/src/types/interface",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "ts.external.directory.path": "D:\\teamPRJ\\fixwesell\\Wesell\\front-server\\node_modules\\typescript\\lib",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;WebServerToolWindowFactoryState&quot;: &quot;false&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;dev&quot;,
+    &quot;last_opened_file_path&quot;: &quot;D:/teamPRJ/fixwesell/Wesell/front-server/src/types/interface&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;ts.external.directory.path&quot;: &quot;D:\\teamPRJ\\fixwesell\\Wesell\\front-server\\node_modules\\typescript\\lib&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
       <recent name="D:\teamPRJ\fixwesell\Wesell\front-server\src\types\interface" />
@@ -72,10 +62,24 @@
       <workItem from="1703777156286" duration="215000" />
       <workItem from="1703777397139" duration="908000" />
       <workItem from="1706053394007" duration="1652000" />
+      <workItem from="1706055126957" duration="337000" />
     </task>
+    <task id="LOCAL-00001" summary="feat: 알림 서비스 구현">
+      <option name="closed" value="true" />
+      <created>1706055299400</created>
+      <option name="number" value="00001" />
+      <option name="presentableId" value="LOCAL-00001" />
+      <option name="project" value="LOCAL" />
+      <updated>1706055299400</updated>
+    </task>
+    <option name="localTasksCounter" value="2" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
     <option name="version" value="3" />
+  </component>
+  <component name="VcsManagerConfiguration">
+    <MESSAGE value="feat: 알림 서비스 구현" />
+    <option name="LAST_COMMIT_MESSAGE" value="feat: 알림 서비스 구현" />
   </component>
 </project>

--- a/front-server/.idea/workspace.xml
+++ b/front-server/.idea/workspace.xml
@@ -5,8 +5,15 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="92f63182-175e-4fe9-8f41-34293aef690c" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/.gitignore" beforeDir="false" afterPath="$PROJECT_DIR$/.gitignore" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/misc.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/misc.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/pages/UserfindbyPwd/PasswordUpdateComponent.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/pages/UserfindbyPwd/PasswordUpdateComponent.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/package.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/App.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/App.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/constant/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/constant/index.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/setupProxy.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/setupProxy.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/types/interface/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/types/interface/index.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/tsconfig.json" beforeDir="false" afterPath="$PROJECT_DIR$/tsconfig.json" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -26,22 +33,29 @@
   <component name="ProjectViewState">
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;WebServerToolWindowFactoryState&quot;: &quot;false&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;feat-157&quot;,
-    &quot;last_opened_file_path&quot;: &quot;C:/Wesell/front-server&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;ts.external.directory.path&quot;: &quot;C:\\Wesell\\front-server\\node_modules\\typescript\\lib&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "WebServerToolWindowFactoryState": "false",
+    "git-widget-placeholder": "dev",
+    "last_opened_file_path": "D:/teamPRJ/fixwesell/Wesell/front-server/src/types/interface",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "ts.external.directory.path": "D:\\teamPRJ\\fixwesell\\Wesell\\front-server\\node_modules\\typescript\\lib",
+    "vue.rearranger.settings.migration": "true"
   }
-}</component>
+}]]></component>
+  <component name="RecentsManager">
+    <key name="CopyFile.RECENT_KEYS">
+      <recent name="D:\teamPRJ\fixwesell\Wesell\front-server\src\types\interface" />
+      <recent name="D:\teamPRJ\fixwesell\Wesell\front-server\src\pages" />
+      <recent name="D:\teamPRJ\fixwesell\Wesell\front-server\public" />
+    </key>
+  </component>
   <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
   <component name="TaskManager">
     <task active="true" id="Default" summary="Default task">
@@ -57,6 +71,7 @@
       <workItem from="1703553873420" duration="1691000" />
       <workItem from="1703777156286" duration="215000" />
       <workItem from="1703777397139" duration="908000" />
+      <workItem from="1706053394007" duration="1652000" />
     </task>
     <servers />
   </component>

--- a/front-server/.idea/workspace.xml
+++ b/front-server/.idea/workspace.xml
@@ -4,7 +4,12 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="92f63182-175e-4fe9-8f41-34293aef690c" name="Changes" comment="feat: 알림 서비스 구현" />
+    <list default="true" id="92f63182-175e-4fe9-8f41-34293aef690c" name="Changes" comment="feat: 알림 서비스 구현">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/package-lock.json" beforeDir="false" afterPath="$PROJECT_DIR$/package-lock.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/package.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/types/interface/index.ts" beforeDir="false" afterPath="$PROJECT_DIR$/src/types/interface/index.ts" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -23,22 +28,22 @@
   <component name="ProjectViewState">
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;WebServerToolWindowFactoryState&quot;: &quot;false&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;dev&quot;,
-    &quot;last_opened_file_path&quot;: &quot;D:/teamPRJ/fixwesell/Wesell/front-server/src/types/interface&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;ts.external.directory.path&quot;: &quot;D:\\teamPRJ\\fixwesell\\Wesell\\front-server\\node_modules\\typescript\\lib&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "WebServerToolWindowFactoryState": "false",
+    "git-widget-placeholder": "feat-186",
+    "last_opened_file_path": "D:/teamPRJ/fixwesell/Wesell/front-server/src/types/interface",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "ts.external.directory.path": "D:\\teamPRJ\\fixwesell\\Wesell\\front-server\\node_modules\\typescript\\lib",
+    "vue.rearranger.settings.migration": "true"
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
       <recent name="D:\teamPRJ\fixwesell\Wesell\front-server\src\types\interface" />
@@ -63,6 +68,7 @@
       <workItem from="1703777397139" duration="908000" />
       <workItem from="1706053394007" duration="1652000" />
       <workItem from="1706055126957" duration="337000" />
+      <workItem from="1706138428493" duration="574000" />
     </task>
     <task id="LOCAL-00001" summary="feat: 알림 서비스 구현">
       <option name="closed" value="true" />

--- a/front-server/package-lock.json
+++ b/front-server/package-lock.json
@@ -20,6 +20,8 @@
         "@types/node": "^16.18.70",
         "@types/react": "^18.2.47",
         "@types/react-dom": "^18.2.18",
+        "colors": "^1.4.0",
+        "express": "^4.18.2",
         "http-proxy-middleware": "^2.0.6",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
@@ -35,7 +37,7 @@
         "react-toastify": "^9.1.3",
         "typescript": "^4.9.5",
         "uuid": "^9.0.1",
-        "web-push": "^3.6.6",
+        "web-push": "^3.6.7",
         "web-vitals": "^2.1.4",
         "webpack-dev-server": "^4.15.1",
         "zustand": "^4.4.7"
@@ -45,8 +47,10 @@
         "@types/react-modal": "^3.16.3",
         "@types/react-router-dom": "^5.3.3",
         "@types/styled-components": "^5.1.34",
+        "@types/web-push": "^3.6.3",
         "eslint": "^8.54.0",
-        "prettier": "^3.1.0"
+        "prettier": "^3.1.0",
+        "ts-node": "^10.9.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2193,6 +2197,28 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "devOptional": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "devOptional": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@csstools/normalize.css": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
@@ -4103,6 +4129,30 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "devOptional": true
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -4516,6 +4566,15 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
+    },
+    "node_modules/@types/web-push": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.3.tgz",
+      "integrity": "sha512-v3oT4mMJsHeJ/rraliZ+7TbZtr5bQQuxcgD7C3/1q/zkAj29c8RE0F9lVZVu3hiQe5Z9fYcBreV7TLnfKR+4mg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -6203,6 +6262,14 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="
     },
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -6392,6 +6459,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "devOptional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -7018,6 +7091,15 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/diff-sequences": {
       "version": "27.5.1",
@@ -11263,6 +11345,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "devOptional": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -15931,6 +16019,64 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "devOptional": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "devOptional": true
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -16310,6 +16456,12 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "devOptional": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "8.1.1",
@@ -17309,6 +17461,15 @@
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/front-server/package-lock.json
+++ b/front-server/package-lock.json
@@ -35,6 +35,7 @@
         "react-toastify": "^9.1.3",
         "typescript": "^4.9.5",
         "uuid": "^9.0.1",
+        "web-push": "^3.6.6",
         "web-vitals": "^2.1.4",
         "webpack-dev-server": "^4.15.1",
         "zustand": "^4.4.7"
@@ -5307,6 +5308,17 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -5689,6 +5701,11 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
+    "node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+    },
     "node_modules/body-parser": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
@@ -5823,6 +5840,11 @@
       "dependencies": {
         "node-int64": "^0.4.0"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -7172,6 +7194,14 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -9118,6 +9148,14 @@
         "entities": "^2.0.0"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
@@ -10985,6 +11023,25 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -16342,6 +16399,47 @@
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/web-push/node_modules/agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/web-push/node_modules/https-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/web-vitals": {

--- a/front-server/package.json
+++ b/front-server/package.json
@@ -15,6 +15,8 @@
     "@types/node": "^16.18.70",
     "@types/react": "^18.2.47",
     "@types/react-dom": "^18.2.18",
+    "colors": "^1.4.0",
+    "express": "^4.18.2",
     "http-proxy-middleware": "^2.0.6",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
@@ -30,7 +32,7 @@
     "react-toastify": "^9.1.3",
     "typescript": "^4.9.5",
     "uuid": "^9.0.1",
-    "web-push": "^3.6.6",
+    "web-push": "^3.6.7",
     "web-vitals": "^2.1.4",
     "webpack-dev-server": "^4.15.1",
     "zustand": "^4.4.7"
@@ -69,7 +71,9 @@
     "@types/react-modal": "^3.16.3",
     "@types/react-router-dom": "^5.3.3",
     "@types/styled-components": "^5.1.34",
+    "@types/web-push": "^3.6.3",
     "eslint": "^8.54.0",
-    "prettier": "^3.1.0"
+    "prettier": "^3.1.0",
+    "ts-node": "^10.9.2"
   }
 }

--- a/front-server/package.json
+++ b/front-server/package.json
@@ -30,6 +30,7 @@
     "react-toastify": "^9.1.3",
     "typescript": "^4.9.5",
     "uuid": "^9.0.1",
+    "web-push": "^3.6.6",
     "web-vitals": "^2.1.4",
     "webpack-dev-server": "^4.15.1",
     "zustand": "^4.4.7"
@@ -41,6 +42,7 @@
     "eject": "react-scripts eject",
     "format": "prettier --check ./src",
     "format:fix": "prettier --write ./src",
+    "server": "ts-node ./src/pages/Notification/server.ts",
     "lint": "eslint ./src",
     "lint:fix": "eslint --fix ./src"
   },

--- a/front-server/public/service-worker.js
+++ b/front-server/public/service-worker.js
@@ -1,0 +1,27 @@
+"use strict";
+/// <reference lib="webworker" />
+function log(...args) {
+    console.log('service-worker:', ...args);
+}
+// https://github.com/microsoft/TypeScript/issues/14877
+((self) => {
+    self.addEventListener('install', (event) => {
+        log('install', { event });
+        event.waitUntil(self.skipWaiting());
+    });
+    self.addEventListener('activate', (event) => {
+        log('activate', { event });
+    });
+    self.addEventListener('push', (event) => {
+        var _a;
+        log('push', { event });
+        const message = (_a = event.data) === null || _a === void 0 ? void 0 : _a.json();
+        event.waitUntil(self.registration.showNotification(message.title, {
+            body: message.body,
+        }));
+    });
+    self.addEventListener('notificationclick', (event) => {
+        log('notificationclick', { event });
+        self.clients.openWindow('https://github.com/leegeunhyeok/web-push');
+    });
+})(self);

--- a/front-server/src/App.tsx
+++ b/front-server/src/App.tsx
@@ -2,7 +2,7 @@ import { Route, Routes } from 'react-router-dom';
 import './App.css';
 import Main from 'pages/Main';
 import Container from 'layouts/Container';
-import { MAIN_PATH, SOCIAL_PATH, UPLOAD_PATH, MYPAGE_PATH, AUTH_PATH } from 'constant';
+import { MAIN_PATH, SOCIAL_PATH, UPLOAD_PATH, MYPAGE_PATH, AUTH_PATH, NOTIFICATION_MAIN_PATH, NOTIFICATION_LOGIN_PATH } from 'constant';
 import Social from 'pages/Social/kakao';
 import UploadBoard from 'pages/board/write/Write';
 import Mypage from 'pages/Mypage';
@@ -21,6 +21,8 @@ import ChatRoomPage from 'pages/ChatRoomPage';
 import RequestPay from 'pages/Pay/beforePay';
 import PayResultPage from 'pages/Pay/detail';
 import TestDetailPage from 'pages/board/testDetail';
+import IndexPage from 'pages/Notification/index';
+import LoginPage from 'pages/Notification/login';
 
 // component: Application 컴포넌트 //
 function App() {
@@ -48,6 +50,8 @@ function App() {
         <Route path="/rooms/:roomId" element={<ChatRoomPage />} />
         <Route path="/payment/:postId" element={<RequestPay />} />
         <Route path="payment/:payId" element={<PayResultPage />} />
+        <Route path={NOTIFICATION_MAIN_PATH()} element={<IndexPage />} />
+        <Route path={NOTIFICATION_LOGIN_PATH()} element={<LoginPage />} />
       </Route>
 
       {/* 테스트 라우터 */}

--- a/front-server/src/constant/index.ts
+++ b/front-server/src/constant/index.ts
@@ -6,3 +6,6 @@ export const USER_PATH = (userEmail: string) => `/user/${userEmail}`;
 export const TEST_PATH = () => '/test';
 export const MYPAGE_PATH = () => '/mypage';
 export const WITHDRAW_PATH = () => '/withdraw';
+export const DATA_PATH = 'data.json';
+export const NOTIFICATION_MAIN_PATH = () => '/notification/index'
+export const NOTIFICATION_LOGIN_PATH = () => '/notification/login'

--- a/front-server/src/pages/Notification/index.tsx
+++ b/front-server/src/pages/Notification/index.tsx
@@ -1,0 +1,302 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+type Store = {
+    pushSupport: boolean;
+    serviceWorkerRegistration: ServiceWorkerRegistration | null;
+    pushSubscription: PushSubscription | null;
+};
+
+type Elements = {
+    currentUserId: HTMLParagraphElement | null;
+    notificationPermission: HTMLParagraphElement | null;
+    pushSupport: HTMLParagraphElement | null;
+    registration: HTMLParagraphElement | null;
+    subscription: HTMLPreElement | null;
+    sendStatus: HTMLParagraphElement | null;
+    message: HTMLInputElement | null;
+    targetUserId: HTMLInputElement | null;
+};
+
+const IndexPage: React.FC = () => {
+    const userId = localStorage.getItem('userId');
+    const elements = useRef<Elements>({
+        // Status text
+        currentUserId: null,
+        registration: null,
+        pushSupport: null,
+        notificationPermission: null,
+        subscription: null,
+        sendStatus: null,
+        // Inputs
+        message: null,
+        targetUserId: null,
+    });
+
+    const [store, setStore] = useState<Store>({
+        pushSupport: false,
+        serviceWorkerRegistration: null,
+        pushSubscription: null,
+    });
+
+    if (!userId) location.href = '/login.tsx';
+
+    async function registerServiceWorker() {
+        if (!('serviceWorker' in navigator)) return;
+
+        try {
+            let registration = await navigator.serviceWorker.getRegistration();
+            if (!registration) {
+                registration = await navigator.serviceWorker.register('/service-worker.js');
+            }
+
+            const pushManager = registration?.pushManager;
+            const pushSubscription = pushManager ? await pushManager.getSubscription() : null;
+
+            setStore((prevStore) => ({
+                ...prevStore,
+                serviceWorkerRegistration: registration ?? null,
+                pushSupport: !!pushManager,
+                pushSubscription: pushSubscription ?? null,
+            }));
+        } catch (error) {
+            console.error('Error registering service worker:', error);
+        }
+    }
+
+    useEffect(() => {
+        updateStatus();
+    }, [store]);
+
+    async function postSubscription(subscription?: PushSubscription) {
+        console.log('postSubscription', { subscription });
+
+        if (!subscription) {
+            showAlert('postSubscription - subscription cannot be empty');
+            return;
+        }
+
+        const response = await fetch('/web-push/subscription', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ userId, subscription }),
+        });
+
+        console.log('postSubscription', { response });
+    }
+
+    async function deleteSubscription() {
+        const response = await fetch('/web-push/subscription', {
+            method: 'DELETE',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ userId }),
+        });
+
+        console.log('deleteSubscription', { response });
+    }
+
+    async function subscribe() {
+        if (store.pushSubscription) {
+            showAlert('subscribe - already subscribed');
+            return;
+        }
+
+        try {
+            const response = await fetch('/web-push/vapid-public-key',
+                {
+                    method: 'GET',
+                }
+            ); // 절대 경로 사용
+            const vapidPublicKey = await response.text();
+            // console.log('subscribe', vapidPublicKey);
+
+            const registration = store.serviceWorkerRegistration;
+
+            if (!registration) {
+                showAlert('subscribe - service worker is not registered');
+                return;
+            }
+
+            const pushManager = registration.pushManager;
+
+            if (!pushManager) {
+                showAlert('subscribe - push manager is not available');
+                return;
+            }
+
+            const subscription = await pushManager.subscribe({
+                applicationServerKey: vapidPublicKey,
+                userVisibleOnly: true,
+            });
+            setStore((prevStore) => ({
+                ...prevStore,
+                pushSubscription: subscription,
+            }));
+            await postSubscription(subscription);
+        } catch (error) {
+            console.error('subscribe', { error });
+        } finally {
+            updateStatus();
+        }
+    }
+
+
+    async function unsubscribe() {
+        const subscription = store.pushSubscription;
+
+        if (!subscription) {
+            showAlert('unsubscribe - push subscription does not exist');
+            return;
+        }
+
+        try {
+            const unsubscribed = await subscription.unsubscribe();
+            setStore((prevStore) => ({
+                ...prevStore,
+                pushSubscription: null,
+            }));
+            console.log('unsubscribe', { unsubscribed });
+            await deleteSubscription();
+        } catch (error) {
+            console.error('unsubscribe', { error });
+        } finally {
+            updateStatus();
+        }
+    }
+
+    async function sendPushNotification() {
+        const targetId = elements.current?.targetUserId?.value;
+        const message = elements.current?.message?.value ?? '';
+        console.log('sendPushNotification', { targetId, message });
+
+        if (!targetId) {
+            showAlert('Target userId cannot be empty');
+            return;
+        }
+
+        const response = await fetch('/web-push/send-push-notification', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ targetId, message }),
+        });
+
+        console.log('sendPushNotification', { response });
+        setText(elements.current?.sendStatus, `(${response.status}) ${response.statusText} / ${new Date()}`);
+    }
+
+    function setText(element: HTMLElement | null, value: string | boolean) {
+        if (!element) return;
+        element.textContent = value.toString();
+        element.classList.remove('t');
+        element.classList.remove('f');
+        typeof value === 'boolean' && element.classList.add(value ? 't' : 'f');
+    }
+
+    async function updateStatus() {
+        setText(elements.current?.currentUserId, userId as string);
+        setText(elements.current?.registration, !!store.serviceWorkerRegistration);
+        setText(elements.current?.pushSupport, store.pushSupport);
+        setText(elements.current?.notificationPermission, Notification.permission);
+        setText(elements.current?.subscription, JSON.stringify(store.pushSubscription, null, 2));
+    }
+
+    function showAlert(message: string) {
+        console.warn(message);
+        alert(message);
+    }
+
+    function logout() {
+        localStorage.removeItem('userId');
+        location.href = '/notification/login';
+    }
+
+    useEffect(() => {
+        elements.current.currentUserId = document.getElementById('current_user_id') as HTMLParagraphElement;
+        elements.current.registration = document.getElementById('registration_status') as HTMLParagraphElement;
+        elements.current.pushSupport = document.getElementById('push_support_status') as HTMLParagraphElement;
+        elements.current.notificationPermission = document.getElementById('notification_permission_status') as HTMLParagraphElement;
+        elements.current.subscription = document.getElementById('subscription') as HTMLPreElement;
+        elements.current.sendStatus = document.getElementById('send_status') as HTMLParagraphElement;
+        elements.current.message = document.getElementById('message') as HTMLInputElement;
+        elements.current.targetUserId = document.getElementById('target_user_id') as HTMLInputElement;
+        updateStatus();
+    }, []);
+
+    useEffect(() => {
+        registerServiceWorker();
+    }, []);
+
+    return (
+        <html>
+        <head>
+            <meta charSet="utf-8" />
+            <meta name="viewport" content="width=device-width,initial-scale=1" />
+            <title>Web Push</title>
+            <link
+                rel="stylesheet"
+                as="style"
+                crossOrigin="anonymous"
+                href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css"
+            />
+            <link rel="stylesheet" href="/css/common.css" />
+        </head>
+        <body>
+        <header>
+            <h1>Web Push</h1>
+        </header>
+        <main>
+            <section>
+                <h2>👀 Status</h2>
+                <div className="item">
+                    Current User ID: <u><p className="inline" id="current_user_id">{userId}</p></u>
+                </div>
+                <div className="item">
+                    ServiceWorker registered: <p className="inline" id="registration_status"></p>
+                    <br />
+                    Push Support: <p className="inline" id="push_support_status"></p>
+                    <br />
+                    Notification permission: <p className="inline" id="notification_permission_status"></p>
+                </div>
+                <div className="item">
+                    <pre id="subscription"></pre>
+                </div>
+            </section>
+            <section>
+                <h2>👉 Subscribe</h2>
+                <div className="item">
+                    <button onClick={subscribe}>Subscribe</button>
+                    <button onClick={unsubscribe}>Unsubscribe</button>
+                </div>
+            </section>
+            <section>
+                <h2>🚀 Send Push Notification</h2>
+                <div className="item">
+                    <input type="text" id="message" defaultValue="Hello, World!" />
+                </div>
+                <div className="item group">
+                    <input className="fill" type="text" id="target_user_id" placeholder="Target User ID" />
+                    <button onClick={sendPushNotification}>Send</button>
+                </div>
+                <div className="item">
+                    <p className="inline secondary" id="send_status">-</p>
+                </div>
+            </section>
+            <section>
+                <h2>🔥 Logout</h2>
+                <div className="item">
+                    <button onClick={logout}>Logout</button>
+                </div>
+            </section>
+        </main>
+        <script src="/index.js"></script>
+        </body>
+        </html>
+    );
+};
+
+export default IndexPage;

--- a/front-server/src/pages/Notification/logger.ts
+++ b/front-server/src/pages/Notification/logger.ts
@@ -1,0 +1,49 @@
+import colors from 'colors';
+
+interface Logger {
+  (...messages: any[]): void;
+}
+
+const LEVEL_COLORS = {
+  info: colors.green,
+  debug: colors.blue,
+  success: colors.green,
+  warning: colors.yellow,
+  danger: colors.red,
+  error: colors.red,
+  critical: colors.magenta
+} as const;
+
+const getTimestamp = () => {
+  const date = new Date();
+
+  const yyyy = date.getFullYear();
+  const MM = date.getMonth().toString().padStart(2, '0');
+  const dd = date.getDate().toString().padStart(2, '0');
+
+  const hh = date.getHours().toString().padStart(2, '0');
+  const mm = date.getMinutes().toString().padStart(2, '0');
+  const ss = date.getSeconds().toString().padStart(2, '0');
+  const aaa = date.getMilliseconds().toString().padStart(3, '0');
+
+  return `${yyyy}-${MM}-${dd} ${hh}:${mm}:${ss}.${aaa}`;
+};
+
+const printLog = (level: keyof typeof LEVEL_COLORS, ...messages: any[]) => {
+  console.log(
+    `[${getTimestamp()}]`.gray,
+    `${LEVEL_COLORS[level](level.toUpperCase())}`,
+    '-',
+    ...messages
+  );
+};
+
+export const logger: Record<keyof typeof LEVEL_COLORS, Logger> = {
+  info: (...messages) => printLog('info', ...messages),
+  debug: (...messages) => printLog('debug', ...messages),
+  success: (...messages) => printLog('success', ...messages),
+  warning: (...messages) => printLog('warning', ...messages),
+  danger: (...messages) => printLog('danger', ...messages),
+  error: (...messages) => printLog('error', ...messages),
+  critical: (...messages) => printLog('critical', ...messages),
+};

--- a/front-server/src/pages/Notification/login.tsx
+++ b/front-server/src/pages/Notification/login.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+const LoginPage: React.FC = () => {
+const handleClick = () => {
+const userId = (document.getElementById('user_id') as HTMLInputElement)?.value;
+if (!userId) {
+alert('userId cannot be empty');
+return;
+}
+localStorage.setItem('userId', userId);
+location.href = './index';
+};
+
+return (
+<html>
+<head>
+  <meta charSet="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Web Push - login</title>
+  <link rel="stylesheet" as="style" crossOrigin="anonymous" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" />
+  <link rel="stylesheet" href="/css/common.css" />
+</head>
+<body>
+<header>
+  <h1>Web Push</h1>
+</header>
+<main>
+  <section>
+    <h2>👋 Login</h2>
+    <div className="group">
+      <input className="fill" id="user_id" type="text" placeholder="User ID" />
+      <button onClick={handleClick}>Go!</button>
+    </div>
+  </section>
+</main>
+</body>
+</html>
+);
+};
+
+export default LoginPage;

--- a/front-server/src/pages/Notification/middlewares.ts
+++ b/front-server/src/pages/Notification/middlewares.ts
@@ -1,0 +1,37 @@
+import { Request, Response, NextFunction } from 'express';
+import { logger } from './logger';
+
+export const responseLogger = (_req: Request, res: Response, next: NextFunction) => {
+  const { originalUrl: url, method } = res.req;
+
+  const afterResponse = () => {
+    res.removeListener('finish', afterResponse);
+    res.removeListener('close', afterResponse);
+
+    let statusCode = res.statusCode.toString();
+    let loggerByStatusCode = logger.info;
+
+    switch (statusCode.charAt(0)) {
+      case '2':
+        statusCode = statusCode.green;
+        break;
+
+      case '3':
+        statusCode = statusCode.yellow;
+        break;
+
+      case '4':
+      case '5':
+        statusCode = statusCode.red;
+        loggerByStatusCode = logger.error;
+        break;
+    }
+
+    loggerByStatusCode(`${method} ${statusCode} ${url}`);
+  };
+
+  res.on('finish', afterResponse);
+  res.on('close', afterResponse);
+
+  next();
+};

--- a/front-server/src/pages/Notification/server.ts
+++ b/front-server/src/pages/Notification/server.ts
@@ -1,0 +1,122 @@
+import fs from 'fs';
+import path from 'path';
+import express from 'express';
+import webpush from 'web-push';
+import { logger } from './logger';
+import { responseLogger } from './middlewares';
+import { Store, PushMessage } from '../../types/interface';
+import {DATA_PATH} from "../../constant";
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+
+
+export const GCM_KEY = process.env.GCM_KEY || '';
+export const SUBJECT = process.env.SUBJECT || '';
+export const VAPID_PUBLIC = process.env.VAPID_PUBLIC || '';
+export const VAPID_PRIVATE = process.env.VAPID_PRIVATE || '';
+
+
+webpush.setGCMAPIKey(GCM_KEY);
+webpush.setVapidDetails(
+  SUBJECT,
+  VAPID_PUBLIC,
+  VAPID_PRIVATE
+);
+
+const store: Store = { data: [] };
+
+const app = express();
+
+app.use(responseLogger)
+app.use(express.json());
+
+app.get('/vapid-public-key', (_req, res) => {
+  console.log(_req);
+  // console.log(VAPID_PUBLIC);
+  res.send(VAPID_PUBLIC);
+});
+
+app.post('/subscription', (req, res) => {
+  const { userId, subscription } = req.body ?? {};
+
+  // replace to new subscription if userId is already exist
+  const index = store.data.findIndex((data) => data.userId === userId);
+  if (~index) store.data[index].subscription = subscription;
+  
+  store.data.push({ userId, subscription });
+  const data = JSON.stringify(store.data);
+
+  fs.writeFile(DATA_PATH, data, 'utf-8', (error) => {
+    if (error) {
+      logger.error('POST /subscription', { error });
+      res.status(500).end();
+    } else {
+      res.status(201).end();
+    }
+  });
+});
+
+app.delete('/subscription', (req, res) => {
+  const { userId } = req.body ?? {};
+
+  // remove target user data
+  const index = store.data.findIndex((data) => data.userId === userId);
+  if (~index) {
+    store.data.splice(index, 1);
+  }
+  
+  const data = JSON.stringify(store.data);
+
+  fs.writeFile(DATA_PATH, data, 'utf-8', (error) => {
+    if (error) {
+      logger.error('DELETE /subscription', { error });
+      res.status(500).end();
+    } else {
+      res.status(200).end();
+    }
+  });
+});
+
+app.post('/send-push-notification', (req, res) => {
+  const { targetId: targetUserId, message } = req.body ?? {};
+  logger.info(`Send push notification to '${targetUserId}' with '${message}'`);
+  const targetUser = store
+    .data
+    .reverse()
+    .find(({ userId }) => userId === targetUserId);
+
+  if (targetUser) {
+    const messageData: PushMessage = {
+      title: 'Web Push | Getting Started',
+      body: message || '(Empty message)',
+    };
+
+    webpush
+      .sendNotification(targetUser.subscription, JSON.stringify(messageData))
+      .then((pushServiceRes) => res.status(pushServiceRes.statusCode).end())
+      .catch((error) => {
+        logger.error('POST /send-push', { error });
+        res.status(error?.statusCode ?? 500).end();
+      });
+  } else {
+    res.status(404).end();
+  }
+});
+
+new Promise<void>((resolve) => {
+  fs.access(DATA_PATH, fs.constants.F_OK, (error) => {
+    // create data file if not exist
+    error && fs.writeFileSync(DATA_PATH, JSON.stringify([]), 'utf-8');
+    resolve();
+  });
+}).then(() => {
+  fs.readFile(DATA_PATH, (error, data) => {
+    if (error) {
+      logger.error('Cannot load data.json', { error });
+    } else {
+      store.data = JSON.parse(data.toString());
+    }
+    app.listen(3333, () => logger.info('Server started'));
+  });
+});

--- a/front-server/src/setupProxy.js
+++ b/front-server/src/setupProxy.js
@@ -63,4 +63,14 @@ module.exports = function (app) {
     }),
   );
 
+    app.use('/web-push',
+        createProxyMiddleware({
+            target: 'http://localhost:3333', //타겟이 되는 api url
+            changeOrigin: true, // 서버 구성에 따른 호스트 헤더 변경 여부 설정
+            pathRewrite: {
+                '^/web-push': '', // 경로에서 '/web-push'를 제거합니다.
+            },
+        }),
+    );
+
 };

--- a/front-server/src/types/interface/index.ts
+++ b/front-server/src/types/interface/index.ts
@@ -1,5 +1,6 @@
 import MessageType from './message-type.interface';
 import Pageable from './pageable.interface';
 import UserInfo from './user-info.interface';
+import { UserSubscription, Store, PushMessage } from './push-message';
 
 export type { MessageType, Pageable, UserInfo, UserSubscription, Store, PushMessage };

--- a/front-server/src/types/interface/index.ts
+++ b/front-server/src/types/interface/index.ts
@@ -2,4 +2,4 @@ import MessageType from './message-type.interface';
 import Pageable from './pageable.interface';
 import UserInfo from './user-info.interface';
 
-export type { MessageType, Pageable, UserInfo };
+export type { MessageType, Pageable, UserInfo, UserSubscription, Store, PushMessage };

--- a/front-server/src/types/interface/push-message.ts
+++ b/front-server/src/types/interface/push-message.ts
@@ -1,0 +1,15 @@
+import { PushSubscription } from 'web-push';
+
+export type UserSubscription = {
+    userId: string;
+    subscription: PushSubscription;
+};
+
+export type Store = {
+    data: UserSubscription[];
+};
+
+export type PushMessage = {
+    title: string;
+    body: string;
+};

--- a/front-server/tsconfig.json
+++ b/front-server/tsconfig.json
@@ -13,7 +13,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
-    "module": "esnext",
+    "module": "commonjs",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
## web-push 라이브러리를 이용한 웹 알림 서비스
1. 푸시 서비스 구독
2. 푸시 서비스 구독자 상대로 메시지와 함께 요청을 보냄
3. 서비스 워커에서 json형태로 받아 처리
4. 웹 알림!

## 참고사항
실행 시 알림 서버, 리액트 서버 두개를 실행시켜야함
```java
// 리액트 서버 (기존 front 서버 시작과 동일)
npm run start
// 알림 서버 (express)
npm run server
``` 

### .env파일에 추가해야될 것들

> GCM_KEY
> SUBJECT
> VAPID_PUBLIC
> VAPID_PRIVATE

GCM_KEY, SUBJECT는 firebase의 푸시 서비스를 사용하는 계정 정보
두가지 VAPID키는 웹 푸시를 보낼때 암호화해서 보내주는 암호화 키

VAPID KEY 생성법
```shell
web-push generate-vapid-keys --json
```  

### package.json 변경사항
```java
// "module": "esnext",
"module": "commonjs",
```
이부분 변경했는데 
간만에 PR올리다보니 실수가 많아서 고치다보니 
테스트 가능한 환경이 아니라서 충돌 확인은 못해봤습니다.
commonjs를 사용하는 파일과 esnext를 사용하는 파일을 따로따로 설정해줘야된다고 하는데 아직 자세히 확인하진 않았어요
