### PR TITLE
배송지 수정 및 배송 상태 업데이트 스케줄링

### DIFF
--- a/deal-service/build.gradle
+++ b/deal-service/build.gradle
@@ -36,12 +36,23 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.2.0'
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
+    implementation 'org.projectlombok:lombok:1.18.26'
+    testImplementation 'junit:junit:4.13.1'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    //test 롬복 사용
+    //resilience4j
+    implementation 'org.springframework.boot:spring-boot-starter-actuator:3.1.5'
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.1.0'
+    implementation 'org.springframework.boot:spring-boot-starter-aop:3.1.5'
+    implementation 'io.github.resilience4j:resilience4j-all:2.1.0'
+    //cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    //test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
     //query dsl 설정
     implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"

--- a/deal-service/src/main/java/com/wesell/dealservice/DealServiceApplication.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/DealServiceApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableDiscoveryClient
 @EnableFeignClients
+@EnableScheduling
 public class DealServiceApplication {
     public static void main(String[] args) {
         SpringApplication.run(DealServiceApplication.class, args);

--- a/deal-service/src/main/java/com/wesell/dealservice/controller/CategoryController.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/controller/CategoryController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v2")
-//@CrossOrigin("http://localhost/3000")
 public class CategoryController {
 
     private final CategoryServiceImpl categoryServiceImpl;

--- a/deal-service/src/main/java/com/wesell/dealservice/global/util/Consumer.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/global/util/Consumer.java
@@ -1,4 +1,4 @@
-package com.wesell.dealservice.util;
+package com.wesell.dealservice.global.util;
 
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/deal-service/src/main/java/com/wesell/dealservice/global/util/Producer.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/global/util/Producer.java
@@ -1,4 +1,4 @@
-package com.wesell.dealservice.util;
+package com.wesell.dealservice.global.util;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;

--- a/deal-service/src/main/java/com/wesell/dealservice/service/DealServiceImpl.java
+++ b/deal-service/src/main/java/com/wesell/dealservice/service/DealServiceImpl.java
@@ -14,7 +14,7 @@ import com.wesell.dealservice.domain.repository.read.DealPostReadRepository;
 import com.wesell.dealservice.global.response.error.exception.CustomException;
 import com.wesell.dealservice.feignClient.ImageFeignClient;
 import com.wesell.dealservice.feignClient.UserFeignClient;
-import com.wesell.dealservice.util.Producer;
+import com.wesell.dealservice.global.util.Producer;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import lombok.extern.log4j.Log4j2;

--- a/front-server/src/pages/Pay/index.tsx
+++ b/front-server/src/pages/Pay/index.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 function getAmount() {
   const[amount, setAmount] = useState();
   useEffect(() => {
-    fetch("/deal-service/api/v1/price", {
+    fetch("/deal-service/api/v2/price", {
       method:"GET"
     })
     .then((response) => response.json())

--- a/pay-service/src/main/java/com/wesell/payservice/PayServiceApplication.java
+++ b/pay-service/src/main/java/com/wesell/payservice/PayServiceApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableDiscoveryClient
 @EnableFeignClients
+@EnableScheduling
 public class PayServiceApplication {
 
     public static void main(String[] args) {

--- a/pay-service/src/main/java/com/wesell/payservice/controller/DeliveryController.java
+++ b/pay-service/src/main/java/com/wesell/payservice/controller/DeliveryController.java
@@ -1,6 +1,7 @@
 package com.wesell.payservice.controller;
 
 import com.wesell.payservice.domain.dto.request.DeliveryRequestDto;
+import com.wesell.payservice.domain.dto.request.DeliveryUpdateRequestDto;
 import com.wesell.payservice.service.delivery.DeliveryService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +23,11 @@ public class DeliveryController {
     @PostMapping("delivery")
     public ResponseEntity<Long> delivery (@RequestBody DeliveryRequestDto requestDto) {
         return new ResponseEntity<>(deliveryService.createDelivery(requestDto), HttpStatus.CREATED);
+    }
+
+    @PutMapping("delivery/update")
+    public ResponseEntity<?> update (@RequestBody DeliveryUpdateRequestDto requestDto){
+        return new ResponseEntity<>(deliveryService.updateDeliveryInfo(requestDto), HttpStatus.OK);
     }
 
     @PutMapping("delivery/start")

--- a/pay-service/src/main/java/com/wesell/payservice/controller/DeliveryController.java
+++ b/pay-service/src/main/java/com/wesell/payservice/controller/DeliveryController.java
@@ -2,7 +2,9 @@ package com.wesell.payservice.controller;
 
 import com.wesell.payservice.domain.dto.request.DeliveryRequestDto;
 import com.wesell.payservice.domain.dto.request.DeliveryUpdateRequestDto;
+import com.wesell.payservice.domain.dto.request.StartDeliveryRequestDto;
 import com.wesell.payservice.service.delivery.DeliveryService;
+import com.wesell.payservice.service.facade.FacadeService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,8 +18,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("api/v2")
 public class DeliveryController {
     private final DeliveryService deliveryService;
-    public DeliveryController(DeliveryService deliveryService) {
+    private final FacadeService facadeService;
+
+    public DeliveryController(DeliveryService deliveryService, FacadeService facadeService) {
         this.deliveryService = deliveryService;
+        this.facadeService = facadeService;
     }
 
     @PostMapping("delivery")
@@ -26,13 +31,14 @@ public class DeliveryController {
     }
 
     @PutMapping("delivery/update")
-    public ResponseEntity<?> update (@RequestBody DeliveryUpdateRequestDto requestDto){
-        return new ResponseEntity<>(deliveryService.updateDeliveryInfo(requestDto), HttpStatus.OK);
+    public ResponseEntity<?> update (@RequestBody DeliveryUpdateRequestDto requestDto) {
+        deliveryService.updateDeliveryInfo(requestDto);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 
     @PutMapping("delivery/start")
-    public ResponseEntity<?> startDelivery(@RequestParam("id") Long deliveryId, @RequestBody Integer shippingNumber){
-        deliveryService.startDelivery(shippingNumber, deliveryId);
+    public ResponseEntity<?> startDelivery(@RequestBody StartDeliveryRequestDto requestDto){
+        deliveryService.startDelivery(requestDto);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 

--- a/pay-service/src/main/java/com/wesell/payservice/domain/dto/request/DeliveryUpdateRequestDto.java
+++ b/pay-service/src/main/java/com/wesell/payservice/domain/dto/request/DeliveryUpdateRequestDto.java
@@ -1,0 +1,20 @@
+package com.wesell.payservice.domain.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeliveryUpdateRequestDto {
+    @NotBlank
+    private Long id;
+    @NotNull
+    private String receiver;
+    @NotNull
+    private String address;
+
+}

--- a/pay-service/src/main/java/com/wesell/payservice/domain/dto/request/DeliveryUpdateRequestDto.java
+++ b/pay-service/src/main/java/com/wesell/payservice/domain/dto/request/DeliveryUpdateRequestDto.java
@@ -10,11 +10,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class DeliveryUpdateRequestDto {
-    @NotBlank
+    @NotNull
     private Long id;
     @NotNull
+    private Long version;
+    @NotBlank
     private String receiver;
-    @NotNull
+    @NotBlank
     private String address;
 
 }

--- a/pay-service/src/main/java/com/wesell/payservice/domain/dto/request/PayRequestDto.java
+++ b/pay-service/src/main/java/com/wesell/payservice/domain/dto/request/PayRequestDto.java
@@ -12,10 +12,10 @@ import lombok.NoArgsConstructor;
 public class PayRequestDto {
     @NotNull
     private Long deliveryId;
-    @NotNull
+    @NotBlank
     private String buyer;
-    @NotBlank
+    @NotNull
     private Long productId;
-    @NotBlank
+    @NotNull
     private Integer type;
 }

--- a/pay-service/src/main/java/com/wesell/payservice/domain/dto/request/StartDeliveryRequestDto.java
+++ b/pay-service/src/main/java/com/wesell/payservice/domain/dto/request/StartDeliveryRequestDto.java
@@ -1,0 +1,18 @@
+package com.wesell.payservice.domain.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class StartDeliveryRequestDto {
+    @NotNull
+    private Long deliveryId;
+    @NotNull
+    private Long version;
+    @NotNull
+    private Integer shippingNumber;
+}

--- a/pay-service/src/main/java/com/wesell/payservice/domain/dto/response/DeliveryResponseDto.java
+++ b/pay-service/src/main/java/com/wesell/payservice/domain/dto/response/DeliveryResponseDto.java
@@ -13,6 +13,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class DeliveryResponseDto {
     @NotBlank
+    private Long id;
+    @NotNull
     private String receiver;
     @NotNull
     private String address;
@@ -20,6 +22,7 @@ public class DeliveryResponseDto {
     private String status;
 
     public DeliveryResponseDto(Delivery delivery) {
+        this.id = delivery.getId();
         this.receiver = delivery.getReceiver();
         this.address = delivery.getAddress();
         this.status = ShippingStatus.PREPARING.getName();

--- a/pay-service/src/main/java/com/wesell/payservice/domain/dto/response/DeliveryResponseDto.java
+++ b/pay-service/src/main/java/com/wesell/payservice/domain/dto/response/DeliveryResponseDto.java
@@ -12,13 +12,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class DeliveryResponseDto {
-    @NotBlank
+    @NotNull
     private Long id;
     @NotNull
+    private Long version;
+    @NotBlank
     private String receiver;
-    @NotNull
+    @NotBlank
     private String address;
-    @NotNull
+    @NotBlank
     private String status;
 
     public DeliveryResponseDto(Delivery delivery) {
@@ -26,5 +28,6 @@ public class DeliveryResponseDto {
         this.receiver = delivery.getReceiver();
         this.address = delivery.getAddress();
         this.status = ShippingStatus.PREPARING.getName();
+        this.version = delivery.getVersion();
     }
 }

--- a/pay-service/src/main/java/com/wesell/payservice/domain/dto/response/MyPaidResponseDto.java
+++ b/pay-service/src/main/java/com/wesell/payservice/domain/dto/response/MyPaidResponseDto.java
@@ -8,13 +8,13 @@ import lombok.Setter;
 
 @Getter @Setter
 public class MyPaidResponseDto {
-    @NotBlank
+    @NotNull
     private Long payId;
-    @NotNull
+    @NotBlank
     private String title;
-    @NotNull
+    @NotBlank
     private String createdAt;
-    @NotNull
+    @NotBlank
     private ShippingStatus status;
 
 }

--- a/pay-service/src/main/java/com/wesell/payservice/domain/dto/response/PayResponseDto.java
+++ b/pay-service/src/main/java/com/wesell/payservice/domain/dto/response/PayResponseDto.java
@@ -12,11 +12,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class PayResponseDto {
 
-    @NotBlank
-    private Long productId;
     @NotNull
-    private String orderNumber;
+    private Long productId;
     @NotBlank
+    private String orderNumber;
+    @NotNull
     private Long amount;
 
 

--- a/pay-service/src/main/java/com/wesell/payservice/domain/entity/Delivery.java
+++ b/pay-service/src/main/java/com/wesell/payservice/domain/entity/Delivery.java
@@ -1,6 +1,7 @@
 package com.wesell.payservice.domain.entity;
 
 import com.wesell.payservice.domain.dto.request.DeliveryRequestDto;
+import com.wesell.payservice.domain.dto.request.DeliveryUpdateRequestDto;
 import com.wesell.payservice.enumerate.ShippingStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -65,6 +66,11 @@ public class Delivery {
                 .createdAt(LocalDate.now())
                 .build();
         return delivery;
+    }
+
+    public void updateDelivery(DeliveryUpdateRequestDto requestDto) {
+        this.receiver = requestDto.getReceiver();
+        this.address = requestDto.getAddress();
     }
 
     public void startDelivery(Integer shippingNumber){

--- a/pay-service/src/main/java/com/wesell/payservice/domain/entity/Delivery.java
+++ b/pay-service/src/main/java/com/wesell/payservice/domain/entity/Delivery.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -24,6 +25,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Delivery {
+    @Version
+    private Long version;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "d_id")
@@ -47,8 +51,9 @@ public class Delivery {
     private LocalDate createdAt;
 
     @Builder
-    public Delivery(ShippingStatus status, Integer shippingNumber,
+    public Delivery(Long version, ShippingStatus status, Integer shippingNumber,
                     String receiver, String address, LocalDate createdAt) {
+        this.version = version;
         this.status = status;
         this.shippingNumber = shippingNumber;
         this.receiver = receiver;

--- a/pay-service/src/main/java/com/wesell/payservice/domain/entity/Pay.java
+++ b/pay-service/src/main/java/com/wesell/payservice/domain/entity/Pay.java
@@ -9,19 +9,23 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.LockModeType;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.repository.Lock;
 
 @Entity @Getter
 @Table(name = "pay")
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Pay {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "p_id")
@@ -54,7 +58,7 @@ public class Pay {
     private Boolean isDeleted;
 
     @Builder
-    public Pay(Long deliveryId, String buyer, Long productId, String orderNumber,
+    public Pay( Long deliveryId, String buyer, Long productId, String orderNumber,
                Long amount, PayType type , LocalDateTime createdAt, Boolean isDeleted) {
         this.deliveryId = deliveryId;
         this.buyer = buyer;
@@ -67,6 +71,7 @@ public class Pay {
     }
 
     //비즈니스 로직
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     public static Pay createPay(PayRequestDto requestDto, String orderNumber, Long amount) {
         PayType type = PayType.UNASSURED;
 

--- a/pay-service/src/main/java/com/wesell/payservice/domain/repository/DeliveryRepository.java
+++ b/pay-service/src/main/java/com/wesell/payservice/domain/repository/DeliveryRepository.java
@@ -1,8 +1,11 @@
 package com.wesell.payservice.domain.repository;
 
 import com.wesell.payservice.domain.entity.Delivery;
+import java.time.LocalDate;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
     Delivery findDeliveryById(Long id);
+    List<Delivery> findDeliveryByCreatedAt(LocalDate date);
 }

--- a/pay-service/src/main/java/com/wesell/payservice/domain/repository/OptimisticRepository.java
+++ b/pay-service/src/main/java/com/wesell/payservice/domain/repository/OptimisticRepository.java
@@ -1,0 +1,18 @@
+package com.wesell.payservice.domain.repository;
+
+import com.wesell.payservice.domain.entity.Delivery;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class OptimisticRepository {
+    @PersistenceContext
+    private EntityManager manager;
+
+    public Delivery findByIdOptimisticLockMode(Long id) {
+        return manager.find(
+                Delivery.class, id, LockModeType.OPTIMISTIC_FORCE_INCREMENT);
+    }
+}

--- a/pay-service/src/main/java/com/wesell/payservice/global/response/error/ErrorCode.java
+++ b/pay-service/src/main/java/com/wesell/payservice/global/response/error/ErrorCode.java
@@ -10,7 +10,14 @@ public enum ErrorCode {
     /**
      * Pay
      */
-    PAY_NOT_FOUND(HttpStatus.NOT_FOUND,"NF","구매 내역이 없습니다.")
+    PAY_NOT_FOUND(HttpStatus.NOT_FOUND,"NF","구매 내역이 없습니다."),
+    REJECT_REASON_SOLD_OUT(HttpStatus.LOCKED, "RRSO", "판매가 완료된 상품입니다."),
+    /**
+     * Delivery
+     */
+    NOT_INVALID_READ(HttpStatus.LOCKED, "NIR", "버전이 맞지 않아 조회가 불가합니다."),
+    NOT_INVALID_UPDATE(HttpStatus.LOCKED, "NIU", "버전이 맞지 않아 수정이 불가합니다"),
+    CANNOT_UPDATE_INFO(HttpStatus.FORBIDDEN, "CUI", "이미 배송이 시작되었습니다.")
     ;
 
     private final HttpStatus status;

--- a/pay-service/src/main/java/com/wesell/payservice/scheduler/DeliveryScheduler.java
+++ b/pay-service/src/main/java/com/wesell/payservice/scheduler/DeliveryScheduler.java
@@ -1,0 +1,23 @@
+package com.wesell.payservice.scheduler;
+
+import com.wesell.payservice.service.delivery.DeliveryService;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryScheduler {
+    private final DeliveryService deliveryService;
+
+    @Scheduled(cron = "${delivery.update-time}")
+    public void updateToFinish(Long deliveryId) {
+        deliveryService.finishDeliveryAll();
+    }
+
+    @PostConstruct
+    public void init() {
+        deliveryService.finishDeliveryAll();
+    }
+}

--- a/pay-service/src/main/java/com/wesell/payservice/service/delivery/DeliveryService.java
+++ b/pay-service/src/main/java/com/wesell/payservice/service/delivery/DeliveryService.java
@@ -1,11 +1,13 @@
 package com.wesell.payservice.service.delivery;
 
 import com.wesell.payservice.domain.dto.request.DeliveryRequestDto;
+import com.wesell.payservice.domain.dto.request.DeliveryUpdateRequestDto;
 import com.wesell.payservice.domain.dto.response.DeliveryResponseDto;
 
 public interface DeliveryService {
     Long createDelivery(DeliveryRequestDto requestDto);
     DeliveryResponseDto getDeliveryInfo(Long id);
+    DeliveryResponseDto updateDeliveryInfo(DeliveryUpdateRequestDto requestDto);
     void startDelivery(Integer shippingNumber, Long deliveryId);
     void finishDelivery(Long deliveryId);
 }

--- a/pay-service/src/main/java/com/wesell/payservice/service/delivery/DeliveryService.java
+++ b/pay-service/src/main/java/com/wesell/payservice/service/delivery/DeliveryService.java
@@ -2,12 +2,14 @@ package com.wesell.payservice.service.delivery;
 
 import com.wesell.payservice.domain.dto.request.DeliveryRequestDto;
 import com.wesell.payservice.domain.dto.request.DeliveryUpdateRequestDto;
+import com.wesell.payservice.domain.dto.request.StartDeliveryRequestDto;
 import com.wesell.payservice.domain.dto.response.DeliveryResponseDto;
 
 public interface DeliveryService {
     Long createDelivery(DeliveryRequestDto requestDto);
     DeliveryResponseDto getDeliveryInfo(Long id);
     DeliveryResponseDto updateDeliveryInfo(DeliveryUpdateRequestDto requestDto);
-    void startDelivery(Integer shippingNumber, Long deliveryId);
+    void startDelivery(StartDeliveryRequestDto requestDto);
     void finishDelivery(Long deliveryId);
+    void finishDeliveryAll();
 }

--- a/pay-service/src/main/java/com/wesell/payservice/service/delivery/DeliveryServiceImpl.java
+++ b/pay-service/src/main/java/com/wesell/payservice/service/delivery/DeliveryServiceImpl.java
@@ -72,7 +72,7 @@ public class DeliveryServiceImpl implements DeliveryService{
 
     @Override
     public void finishDeliveryAll() {
-        LocalDate deadline = LocalDate.now().minusWeeks(1);
+        LocalDate deadline = LocalDate.now().minusDays(10);
         List<Delivery> deliveries = deliveryRepository.findDeliveryByCreatedAt(deadline);
         deliveries.forEach(Delivery::finishDelivery);
     }

--- a/pay-service/src/main/java/com/wesell/payservice/service/delivery/DeliveryServiceImpl.java
+++ b/pay-service/src/main/java/com/wesell/payservice/service/delivery/DeliveryServiceImpl.java
@@ -2,10 +2,16 @@ package com.wesell.payservice.service.delivery;
 
 import com.wesell.payservice.domain.dto.request.DeliveryRequestDto;
 import com.wesell.payservice.domain.dto.request.DeliveryUpdateRequestDto;
+import com.wesell.payservice.domain.dto.request.StartDeliveryRequestDto;
 import com.wesell.payservice.domain.dto.response.DeliveryResponseDto;
 import com.wesell.payservice.domain.entity.Delivery;
 import com.wesell.payservice.domain.repository.DeliveryRepository;
+import com.wesell.payservice.domain.repository.OptimisticRepository;
+import com.wesell.payservice.global.response.error.ErrorCode;
+import com.wesell.payservice.global.response.error.exception.CustomException;
 import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 
@@ -14,8 +20,10 @@ import org.springframework.stereotype.Service;
 @Log4j2
 public class DeliveryServiceImpl implements DeliveryService{
     private final DeliveryRepository deliveryRepository;
-    public DeliveryServiceImpl(DeliveryRepository deliveryRepository) {
+    private final OptimisticRepository optimisticRepository;
+    public DeliveryServiceImpl(DeliveryRepository deliveryRepository, OptimisticRepository optimisticRepository) {
         this.deliveryRepository = deliveryRepository;
+        this.optimisticRepository = optimisticRepository;
     }
 
     @Override
@@ -33,19 +41,39 @@ public class DeliveryServiceImpl implements DeliveryService{
 
     @Override
     public DeliveryResponseDto updateDeliveryInfo(DeliveryUpdateRequestDto requestDto) {
-        Delivery delivery = deliveryRepository.findDeliveryById(requestDto.getId());
+        Delivery delivery = optimisticRepository.findByIdOptimisticLockMode(requestDto.getId());
+
+        if(delivery.getShippingNumber() != null){
+            throw new CustomException(ErrorCode.CANNOT_UPDATE_INFO);
+        } else if(!delivery.getVersion().equals(requestDto.getVersion())) {
+            throw new CustomException(ErrorCode.NOT_INVALID_UPDATE);
+        }
+
+        delivery.updateDelivery(requestDto);
         return new DeliveryResponseDto(delivery);
     }
 
     @Override
-    public void startDelivery(Integer shippingNumber, Long deliveryId) {
-        Delivery delivery = deliveryRepository.findDeliveryById(deliveryId);
-        delivery.startDelivery(shippingNumber);
+    public void startDelivery(StartDeliveryRequestDto requestDto) {
+        Delivery delivery = deliveryRepository.findDeliveryById(requestDto.getDeliveryId());
+
+        if(!delivery.getVersion().equals(requestDto.getVersion())) {
+            throw new CustomException(ErrorCode.NOT_INVALID_READ);
+        }
+
+        delivery.startDelivery(requestDto.getShippingNumber());
     }
 
     @Override
     public void finishDelivery(Long deliveryId) {
         Delivery delivery = deliveryRepository.findDeliveryById(deliveryId);
         delivery.finishDelivery();
+    }
+
+    @Override
+    public void finishDeliveryAll() {
+        LocalDate deadline = LocalDate.now().minusWeeks(1);
+        List<Delivery> deliveries = deliveryRepository.findDeliveryByCreatedAt(deadline);
+        deliveries.forEach(Delivery::finishDelivery);
     }
 }

--- a/pay-service/src/main/java/com/wesell/payservice/service/delivery/DeliveryServiceImpl.java
+++ b/pay-service/src/main/java/com/wesell/payservice/service/delivery/DeliveryServiceImpl.java
@@ -1,6 +1,7 @@
 package com.wesell.payservice.service.delivery;
 
 import com.wesell.payservice.domain.dto.request.DeliveryRequestDto;
+import com.wesell.payservice.domain.dto.request.DeliveryUpdateRequestDto;
 import com.wesell.payservice.domain.dto.response.DeliveryResponseDto;
 import com.wesell.payservice.domain.entity.Delivery;
 import com.wesell.payservice.domain.repository.DeliveryRepository;
@@ -27,6 +28,12 @@ public class DeliveryServiceImpl implements DeliveryService{
     @Override
     public DeliveryResponseDto getDeliveryInfo(Long id) {
         Delivery delivery = deliveryRepository.findDeliveryById(id);
+        return new DeliveryResponseDto(delivery);
+    }
+
+    @Override
+    public DeliveryResponseDto updateDeliveryInfo(DeliveryUpdateRequestDto requestDto) {
+        Delivery delivery = deliveryRepository.findDeliveryById(requestDto.getId());
         return new DeliveryResponseDto(delivery);
     }
 

--- a/pay-service/src/main/java/com/wesell/payservice/service/facade/FacadeService.java
+++ b/pay-service/src/main/java/com/wesell/payservice/service/facade/FacadeService.java
@@ -1,5 +1,6 @@
 package com.wesell.payservice.service.facade;
 
+import com.wesell.payservice.domain.dto.request.DeliveryUpdateRequestDto;
 import com.wesell.payservice.domain.dto.response.DetailFacadeResponseDto;
 import com.wesell.payservice.domain.dto.response.PayResponseDto;
 import com.wesell.payservice.domain.dto.search.PayViewDao;
@@ -28,4 +29,5 @@ public class FacadeService {
         dto.setPayDto(new PayResponseDto(payViewDao.searchPayById(payId)));
         return dto;
     }
+
 }

--- a/pay-service/src/main/resources/application.yml
+++ b/pay-service/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
     driver-class-name: ${driver-class-name}
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true
@@ -41,3 +41,6 @@ logging:
 iamport:
   key: ${key}
   secret: ${secret}
+
+delivery:
+  update-time: ${update-time}

--- a/pay-service/src/test/java/com/wesell/payservice/service/pay/PayServiceImplTest.java
+++ b/pay-service/src/test/java/com/wesell/payservice/service/pay/PayServiceImplTest.java
@@ -1,0 +1,59 @@
+package com.wesell.payservice.service.pay;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.wesell.payservice.domain.dto.request.DeliveryUpdateRequestDto;
+import com.wesell.payservice.domain.dto.request.PayRequestDto;
+import com.wesell.payservice.domain.entity.Delivery;
+import com.wesell.payservice.domain.entity.Pay;
+import com.wesell.payservice.domain.repository.PayRepository;
+import com.wesell.payservice.enumerate.PayType;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class PayServiceImplTest {
+    @Autowired
+    private PayServiceImpl service;
+    @Autowired
+    private PayRepository repository;
+
+    @BeforeEach
+    public void insert() {
+        Pay pay1 = new Pay(1L, 1L, "내가 구매자uuid", 1L, "ordernum", PayType.ASSURED, 3000L, LocalDateTime.now(),false);
+        repository.saveAndFlush(pay1);
+    }
+
+    @AfterEach
+    public void delete() {
+        repository.deleteAll();
+    }
+
+    @Test
+    void 동시_구매_테스트() throws InterruptedException {
+        int PEOPLE = 10; //10명이 동시 요청
+        CountDownLatch countDownLatch = new CountDownLatch(PEOPLE);
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+
+        for (int i =0 ;i<100; i++ ){ //반복문으로 요청 100개 넣기
+            executorService.submit(() -> { //개별 스레드가 호출할 요청
+                try{
+                    service.createPay(new PayRequestDto( 1L, "구매하고싶어요", 1L, 0));
+                } finally {
+                    countDownLatch.countDown(); //요청 들어간 스레드는 대기
+                }
+            });
+        }
+        countDownLatch.await();
+
+        assertEquals(1, repository.findAllById(Collections.singleton(1L)).size());
+    }
+}


### PR DESCRIPTION
1. 결제 요청 시 가격 브라우저 캐싱
```java
return ResponseEntity.ok().cacheControl(cacheControl)
                .body(price);
```

2. 구매자 측에서 배송지 수정, 판매자 측에서 배송지 조회 시 동시성 문제 버저닝으로 관리
사용자가 배송 객체를 조회할 때 버전이 1씩 올라갑니다.
```java
public Delivery findByIdOptimisticLockMode(Long id) {
        return manager.find(
                Delivery.class, id, LockModeType.OPTIMISTIC_FORCE_INCREMENT);
    }
```
버전이 맞지 않으면 접근 불가능 합니다.
```java
else if(!delivery.getVersion().equals(requestDto.getVersion())) {
            throw new CustomException(ErrorCode.NOT_INVALID_UPDATE);
```

3. 배송 시작이 10일이 지나면, 배송 상태를 '배송 완료'로 일괄 업데이트 합니다.
```java
 public void finishDeliveryAll() {
        LocalDate deadline = LocalDate.now().minusDays(10);
```

4. 구매버튼 동시성 문제 
비관적 락을 걸어서 최초 첫 번째 요청만 받도록 구현했습니다. 해당 기능에 대한 테스트 코드 구현했습니다.

5. 상황에 따른 errorcode 추가했습니다.
