### PR TITLE
Feat 201 : [Auth & User] 회원 탈퇴 DB 처리 로직 수정

### DIFF
--- a/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AuthController.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/controller/AuthController.java
@@ -73,6 +73,20 @@ public class AuthController {
                 );
     }
 
+    // 로그아웃
+    @GetMapping("logout")
+    public ResponseEntity<?> logout() {
+        log.debug("client 로그아웃 GET 요청");
+        ResponseCookie deleteAccessToken = cookieUtil.deleteAccessTokenCookie();
+        ResponseCookie deleteRefreshToken = cookieUtil.deleteRefreshTokenCookie();
+
+        return ResponseEntity
+                .ok()
+                .header(HttpHeaders.SET_COOKIE, deleteAccessToken.toString())
+                .header(HttpHeaders.SET_COOKIE, deleteRefreshToken.toString())
+                .body(SuccessApiResponse.of(SuccessCode.OK));
+    }
+
     // 소셜 로그인 - KAKAO
     @PostMapping("kakao/auth-code")
     public ResponseEntity<?> kakaoAuthCode(@RequestBody String authCode, HttpServletRequest request) {
@@ -107,16 +121,11 @@ public class AuthController {
     public ResponseEntity<?> kakaoLogout() {
         log.info("client 카카오 로그아웃 GET 요청");
 
-        log.debug("쿠키 삭제");
-        ResponseCookie deleteAccessToken = cookieUtil.deleteAccessTokenCookie();
-        ResponseCookie deleteRefreshToken = cookieUtil.deleteRefreshTokenCookie();
-        ResponseCookie deleteJSESSIONID = cookieUtil.deleteJSESSIONIDCookie();
-
         return ResponseEntity
                 .ok()
-                .header(HttpHeaders.SET_COOKIE, deleteAccessToken.toString())
-                .header(HttpHeaders.SET_COOKIE, deleteRefreshToken.toString())
-                .header(HttpHeaders.SET_COOKIE, deleteJSESSIONID.toString())
+                .header(HttpHeaders.SET_COOKIE, cookieUtil.deleteAccessTokenCookie().toString())
+                .header(HttpHeaders.SET_COOKIE, cookieUtil.deleteRefreshTokenCookie().toString())
+                .header(HttpHeaders.SET_COOKIE, cookieUtil.deleteJSESSIONIDCookie().toString())
                 .body(SuccessApiResponse.of(SuccessCode.OK));
     }
 
@@ -140,20 +149,6 @@ public class AuthController {
                 .body(SuccessApiResponse.of(SuccessCode.OK));
     }
 
-    // 로그아웃
-    @GetMapping("logout")
-    public ResponseEntity<?> logout() {
-        log.debug("client 로그아웃 GET 요청");
-        ResponseCookie deleteAccessToken = cookieUtil.deleteAccessTokenCookie();
-        ResponseCookie deleteRefreshToken = cookieUtil.deleteRefreshTokenCookie();
-
-        return ResponseEntity
-                .ok()
-                .header(HttpHeaders.SET_COOKIE, deleteAccessToken.toString())
-                .header(HttpHeaders.SET_COOKIE, deleteRefreshToken.toString())
-                .body(SuccessApiResponse.of(SuccessCode.OK));
-    }
-
     // 회원탈퇴 전 비밀번호 확인
     @PostMapping("delete/pw-check")
     public ResponseEntity<?> checkPw(@RequestBody DeleteUserPwCheckRequestDto requestDto) {
@@ -166,15 +161,13 @@ public class AuthController {
     @DeleteMapping("delete/{uuid}")
     public ResponseEntity<?> deleteUser(@PathVariable(value = "uuid") String uuid) {
         log.debug("client 회원탈퇴 DELETE 요청");
-        ResponseCookie deleteAccessToken = cookieUtil.deleteAccessTokenCookie();
-        ResponseCookie deleteRefreshToken = cookieUtil.deleteRefreshTokenCookie();
 
         authService.deleteUser(uuid);
 
         return ResponseEntity
                 .ok()
-                .header(HttpHeaders.SET_COOKIE, deleteAccessToken.toString())
-                .header(HttpHeaders.SET_COOKIE, deleteRefreshToken.toString())
+                .header(HttpHeaders.SET_COOKIE, cookieUtil.deleteAccessTokenCookie().toString())
+                .header(HttpHeaders.SET_COOKIE, cookieUtil.deleteRefreshTokenCookie().toString())
                 .body(SuccessApiResponse.of(SuccessCode.OK));
     }
 
@@ -204,15 +197,12 @@ public class AuthController {
         }else{
             log.info("cookie or session is null");
         }
-        
-        ResponseCookie deleteAccessToken = cookieUtil.deleteAccessTokenCookie();
-        ResponseCookie deleteRefreshToken = cookieUtil.deleteRefreshTokenCookie();
-        ResponseCookie deleteJSESSIONID = cookieUtil.deleteJSESSIONIDCookie();
+
         return ResponseEntity
                 .ok()
-                .header(HttpHeaders.SET_COOKIE, deleteAccessToken.toString())
-                .header(HttpHeaders.SET_COOKIE, deleteRefreshToken.toString())
-                .header(HttpHeaders.SET_COOKIE, deleteJSESSIONID.toString())
+                .header(HttpHeaders.SET_COOKIE, cookieUtil.deleteAccessTokenCookie().toString())
+                .header(HttpHeaders.SET_COOKIE, cookieUtil.deleteRefreshTokenCookie().toString())
+                .header(HttpHeaders.SET_COOKIE, cookieUtil.deleteJSESSIONIDCookie().toString())
                 .body(SuccessApiResponse.of(SuccessCode.OK));
     }
 

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/domain/entity/AuthUser.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/domain/entity/AuthUser.java
@@ -3,6 +3,8 @@ package com.wesell.authenticationserver.domain.entity;
 import com.wesell.authenticationserver.domain.enum_.Role;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import java.io.Serializable;
 
@@ -11,13 +13,15 @@ import java.io.Serializable;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name="auth")
+@SQLDelete(sql = "UPDATE auth SET is_deleted = true WHERE a_uuid = ?")
+@Where(clause = "is_deleted = false")
 public class AuthUser {
 
     @Id
     @Column(name="a_uuid", nullable = false, length = 50)
     private String uuid;
 
-    @Column(name = "a_email", unique = true ,nullable = false, length = 60)
+    @Column(name = "a_email", nullable = false, length = 60)
     private String email;
 
     @Column(name= "a_password", length = 100)
@@ -40,9 +44,8 @@ public class AuthUser {
     public void changeIsForced(){
         isForced = !isForced;
     }
-
-    public String deleteUser(String comment){
-        return this.uuid += "__" + comment;
+    public void changeIsDeleted(){
+        isDeleted = !isDeleted;
     }
 
     public void changePassword(String newPassword) {

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/domain/entity/KakaoUser.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/domain/entity/KakaoUser.java
@@ -22,21 +22,8 @@ public class KakaoUser {
     @Column(name= "k_role", nullable = false, length = 20)
     private Role role;
 
-    @Column(name = "is_deleted")
-    private boolean isDeleted; // 삭제 여부
-
-    @Column(name = "is_forced")
-    private boolean isForced; // 강제 탈퇴 여부
-
     public void changeRole(Role role){
         this.role = role;
     }
 
-    public void changeIsForced(){
-        isForced = !isForced;
-    }
-
-    public void changeIsDeleted(){
-        isDeleted = !isDeleted;
-    }
 }

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/domain/feign/UserServiceFeignClient.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/domain/feign/UserServiceFeignClient.java
@@ -15,6 +15,6 @@ public interface UserServiceFeignClient {
     String findID(@RequestBody String phoneNumber);
 
     @DeleteMapping("api/v2/users/{uuid}")
-    ResponseEntity<Void> deleteUser(@PathVariable(value="uuid") String uuid, @RequestParam String deletedUuid);
+    ResponseEntity<Void> deleteUser(@PathVariable(value="uuid") String uuid);
 
 }

--- a/authentication-server/src/main/java/com/wesell/authenticationserver/service/AuthServiceImpl.java
+++ b/authentication-server/src/main/java/com/wesell/authenticationserver/service/AuthServiceImpl.java
@@ -20,6 +20,7 @@ import com.wesell.authenticationserver.service.dto.response.CreateUserFeignRespo
 import com.wesell.authenticationserver.domain.feign.UserServiceFeignClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,6 +46,9 @@ public class AuthServiceImpl implements AuthService {
     private final AuthUserLoadRepository authUserLoadRepository;
     private final CustomPasswordEncoder passwordEncoder;
     private final CustomConverter customConverter;
+
+    @Value("${delete.command}")
+    private String deleteCommand;
 
     /**
      * 회원 가입 기능
@@ -166,7 +170,7 @@ public class AuthServiceImpl implements AuthService {
     }
 
     /**
-     * 강제 탈퇴 여부 변경 기능
+     * 강제 탈퇴
      *
      * @param uuid
      * @return
@@ -180,14 +184,12 @@ public class AuthServiceImpl implements AuthService {
 
         if (optionalAuthUser.isPresent()) {
             AuthUser authUser = optionalAuthUser.get();
-            authUser.deleteUser("delete");
+            authUser.changeIsDeleted();
             authUser.changeIsForced();
-            authUserRepository.saveAndFlush(authUser);
-        } else if (optionalKakaoUser.isPresent()) {
+            authUserRepository.save(authUser); // 하나의 쿼리로 관리하기 위함
+        } else if (optionalKakaoUser.isPresent()) { // 카카오 정책에 따라 회원탈퇴 즉시 파기
             KakaoUser kakaoUser = optionalKakaoUser.get();
-            kakaoUser.changeIsDeleted();
-            kakaoUser.changeIsForced();
-            kakaoUserRepository.saveAndFlush(kakaoUser);
+            kakaoUserRepository.delete(kakaoUser);
         } else {
             throw new CustomException(ErrorCode.NOT_FOUND_USER);
         }
@@ -225,21 +227,19 @@ public class AuthServiceImpl implements AuthService {
         log.debug("회원 탈퇴");
 
         log.debug("탈퇴할 회원 조회");
-        AuthUser authUser = authUserRepository.findById(uuid).orElseThrow(() -> {
-            throw new CustomException(ErrorCode.NOT_FOUND_USER);
-        });
+        Optional<AuthUser> authUserOptional = authUserRepository.findById(uuid);
+        Optional<KakaoUser> kakaoUserOptional = kakaoUserRepository.findById(uuid);
 
         log.debug("탈퇴한 회원으로 변경 - DB 반영");
-        String deletedUuid = authUser.deleteUser("delete");
-        authUserRepository.saveAndFlush(authUser);
-
-        log.debug("User-Service Api Call - 회원가입 요청");
-        try {
-            userServiceFeignClient.deleteUser(uuid, deletedUuid);
-        } catch (Exception e) {
-            log.error("유저 서비스로 Feign 요청 시 오류 발생.");
-            log.error("detail : {}", e.getMessage());
-            throw new CustomException(ErrorCode.USER_SERVICE_FEIGN_ERROR);
+        if(authUserOptional.isPresent()){
+            AuthUser authUser = authUserOptional.get();
+            authUserRepository.delete(authUser);
+        }
+        else if(kakaoUserOptional.isPresent()){
+            KakaoUser kakaoUser = kakaoUserOptional.get();
+            kakaoUserRepository.delete(kakaoUser);
+        }else{
+            throw new CustomException(ErrorCode.NOT_FOUND_USER);
         }
     }
 

--- a/user-service/src/main/java/com/wesell/userservice/controller/UserFeignController.java
+++ b/user-service/src/main/java/com/wesell/userservice/controller/UserFeignController.java
@@ -49,8 +49,8 @@ public class UserFeignController {
 
     // 인증/인가 - 회원 탈퇴
     @DeleteMapping("users/{uuid}")
-    public void deleteUserEntity(@PathVariable String uuid, @RequestParam String deletedUuid) {
-        userService.delete(uuid, deletedUuid);
+    public void deleteUserEntity(@PathVariable String uuid) {
+        userService.delete(uuid);
     }
 
     // 판매글 - 판매 상세 - 닉네임, 판매횟수 조회

--- a/user-service/src/main/java/com/wesell/userservice/domain/service/UserService.java
+++ b/user-service/src/main/java/com/wesell/userservice/domain/service/UserService.java
@@ -11,7 +11,7 @@ public interface UserService {
     public void update(String uuid, SignupRequestDto requestDto);
 
     // 회원 삭제
-    public void delete(String uuid, String deletedUuid);
+    public void delete(String uuid);
 
     // 닉네임 중복 여부
     public void checkNickname(String nickname);

--- a/user-service/src/main/java/com/wesell/userservice/service/UserServiceImpl.java
+++ b/user-service/src/main/java/com/wesell/userservice/service/UserServiceImpl.java
@@ -75,11 +75,10 @@ public class UserServiceImpl implements UserService {
      */
     @Transactional
     @Override
-    public void delete(String uuid, String deletedUuid) {
+    public void delete(String uuid) {
         User user = userRepository.findById(uuid).orElseThrow(
                 () -> new CustomException(ErrorCode.NOT_FOUND_USER)
         );
-        user.deleteUser(deletedUuid);
         userRepository.saveAndFlush(user);
     }
 


### PR DESCRIPTION
## 🌠 IsDeleted 정책 유지
- issue 내 명시한 uuid 값 수정 방식에 대한 문제점 발견하여 기존 방식 유지 및 리팩토링 진행했습니다.
- JPA 영속성 컨텍스트 내 관리되는 엔티티의 Id(기본키) 값은 수정이 불가능하며, 수정이 필요한 경우, 기존의 레코드 삭제 후 새로운 값을 넣는 방식으로 구현해야 합니다. 그러나 이러한 경우, 수정 시 쿼리 하나만 발생할 것이 2개의 쿼리문이 발생하게 됩니다.
또한, 로그인 시 회원 이메일 조회 시 탈퇴한 회원의 정보도 남아있기 때문에 조회 시 단일 조회가 안될 경우가 있어 이를 처리하려면 기존의 코드보다 상대적으로 로직이 복잡해진다고 판단하여 기존의 방식을 유지하도록 구현하였습니다.
- 위에서 언급한 로그인 시 탈퇴한 회원 정보를 제외하고 조회가 이뤄지도록 @Where 어노테이션을 추가하여 쿼리 발생 시 where 뒤에 is_deleted 가 false인 경우, 조회하도록 추가하였습니다.
- 추가로 @SqlDelete 어노테이션을 활용하여 repository delete 메서드 사용 시, sql 속성에 정의한 쿼리문이 발생하도록 설정 추가했습니다.
![image](https://github.com/playdata-final-project-team/Wesell/assets/118423671/3d98d4c1-abe8-47f8-922a-be068d2a4990)

## 🌠 카카오 회원은 회원 탈퇴 시  DB 데이터 파기

![회원 탈퇴 시 파기 요청](https://github.com/playdata-final-project-team/Wesell/assets/118423671/8e58e716-c974-41af-8227-761163f54133)

- 위처럼 카카오 문서 상에 회원 탈퇴 시 저장한 정보를 즉시 파기하라는 문구에 따라 서비스 카카오 회원 DB의 해당 정보를 바로 파기하도록 로직 수정하였습니다.