### PR TITLE
feat: Redis 성능 테스트 및 게시물 삭제, 수정 로직 추가

### DIFF
--- a/board-service/src/main/java/com/wesell/boardservice/controller/PostController.java
+++ b/board-service/src/main/java/com/wesell/boardservice/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.wesell.boardservice.controller;
 
 import com.wesell.boardservice.domain.dto.request.PostRequestDto;
+import com.wesell.boardservice.domain.dto.request.PostUpdateRequestDto;
 import com.wesell.boardservice.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,20 @@ public class PostController {
     public ResponseEntity<?> post(@RequestBody PostRequestDto postRequestDto, @PathVariable("boardId") Long boardId) {
         postService.save(postRequestDto, boardId);
         return ResponseEntity.ok("게시물이 등록되었습니다.");
+    }
+
+    //게시글 삭제기능
+    @DeleteMapping("/post/delete/{postId}")
+    public ResponseEntity<?> deletePostInfo(@PathVariable("postId")Long postId) {
+        postService.deletePost(postId);
+        return ResponseEntity.ok("게시물이 삭제되었습니다.");
+    }
+
+    //게시물 수정기능
+    @PutMapping("/post/update/{postId}")
+    public ResponseEntity<?> updatePostInfo(@RequestBody PostUpdateRequestDto postUpdateRequestDto, @PathVariable("postId")Long postId) {
+        postService.updatePost(postUpdateRequestDto, postId);
+        return ResponseEntity.ok("게시물이 수정되었습니다.");
     }
     // 게시글 조회 기능
     @GetMapping("/post/{postId}")

--- a/board-service/src/main/java/com/wesell/boardservice/controller/RedisTestController.java
+++ b/board-service/src/main/java/com/wesell/boardservice/controller/RedisTestController.java
@@ -1,0 +1,47 @@
+package com.wesell.boardservice.controller;
+
+import com.wesell.boardservice.domain.dto.reponse.PageResponseDto;
+import com.wesell.boardservice.service.BoardService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Log4j2
+@RequestMapping("api/v1/redis")
+public class RedisTestController {
+
+    private final BoardService boardService;
+
+    @GetMapping("{boardId}/1")
+    public ResponseEntity<?> selectNoRedis(@RequestParam(name = "page", defaultValue = "1")Integer page, @PathVariable("boardId")Long boardId) {
+
+        long startTime = System.currentTimeMillis();
+        PageResponseDto result = boardService.getAllPostsNoRedis(page, boardId);
+        log.info("캐시 적용 전 :" + (System.currentTimeMillis() - startTime)+ "ms");
+        log.info("캐시 적용 전 :" + (System.currentTimeMillis() - startTime)+ "ms");
+        log.info("캐시 적용 전 :" + (System.currentTimeMillis() - startTime)+ "ms");
+        log.info("캐시 적용 전 :" + (System.currentTimeMillis() - startTime)+ "ms");
+        log.info("캐시 적용 전 :" + (System.currentTimeMillis() - startTime)+ "ms");
+        log.info("캐시 적용 전 :" + (System.currentTimeMillis() - startTime)+ "ms");
+        return ResponseEntity.ok().body(result);
+    }
+
+    @GetMapping("{boardId}/2")
+    public ResponseEntity<?> selectRedis(@RequestParam(name = "page", defaultValue = "1")Integer page, @PathVariable("boardId")Long boardId) {
+
+        long startTime = System.currentTimeMillis();
+        PageResponseDto result = boardService.getAllPosts(page, boardId);
+        log.info("캐시 적용 후 :" + (System.currentTimeMillis() - startTime)+ "ms");
+        log.info("캐시 적용 후 :" + (System.currentTimeMillis() - startTime)+ "ms");
+        log.info("캐시 적용 후 :" + (System.currentTimeMillis() - startTime)+ "ms");
+        log.info("캐시 적용 후 :" + (System.currentTimeMillis() - startTime)+ "ms");
+        log.info("캐시 적용 후 :" + (System.currentTimeMillis() - startTime)+ "ms");
+        log.info("캐시 적용 후 :" + (System.currentTimeMillis() - startTime)+ "ms");
+        return ResponseEntity.ok().body(result);
+    }
+}

--- a/board-service/src/main/java/com/wesell/boardservice/domain/dto/request/PostUpdateRequestDto.java
+++ b/board-service/src/main/java/com/wesell/boardservice/domain/dto/request/PostUpdateRequestDto.java
@@ -1,0 +1,16 @@
+package com.wesell.boardservice.domain.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostUpdateRequestDto {
+    @NotBlank
+    private String title;
+    @NotBlank
+    private String content;
+}

--- a/board-service/src/main/java/com/wesell/boardservice/domain/entity/Post.java
+++ b/board-service/src/main/java/com/wesell/boardservice/domain/entity/Post.java
@@ -48,6 +48,14 @@ public class Post {
     @Where(clause = "parent_id is null")
     private List<Comment> commentList = new ArrayList<>();
 
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
     public void addClick() {
         this.click++;
     }

--- a/board-service/src/main/java/com/wesell/boardservice/error/ErrorCode.java
+++ b/board-service/src/main/java/com/wesell/boardservice/error/ErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "400", "존재하지 않는 게시물입니다.");
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "400", "존재하지 않는 게시물입니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "400", "댓글을 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/board-service/src/main/java/com/wesell/boardservice/service/BoardService.java
+++ b/board-service/src/main/java/com/wesell/boardservice/service/BoardService.java
@@ -41,4 +41,20 @@ public class BoardService {
                 .build();
 
     }
+
+    public PageResponseDto getAllPostsNoRedis(int page, Long boardId) {
+        int pageLimit = 5;
+
+        Page<Post> posts =postRepository.findAllByPostAndBoard(boardId, PageRequest.of(page, pageLimit)).orElseThrow(
+                () -> new CustomException(ErrorCode.POST_NOT_FOUND)
+        );
+
+        return PageResponseDto.builder()
+                .dtoList(posts.map(AllPostsResponseDto::new).toList())
+                .page(page)
+                .totalElements(posts.getTotalElements())
+                .size(posts.getSize())
+                .build();
+
+    }
 }

--- a/board-service/src/main/java/com/wesell/boardservice/service/CommentService.java
+++ b/board-service/src/main/java/com/wesell/boardservice/service/CommentService.java
@@ -30,7 +30,7 @@ public class CommentService {
     // 댓글 조회
     public List<CommentResponseDto> findCommentsByPostId(Long postId) {
         postRepository.findById(postId).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
-        List<Comment> comments = commentRepository.findCommentByPostId(postId).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+        List<Comment> comments = commentRepository.findCommentByPostId(postId).orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
         return convertNestedStructure(comments);
     }
     // 댓글 저장
@@ -44,7 +44,7 @@ public class CommentService {
                         commentRequestDto.getWriter(),
                         commentRequestDto.getParentId() != null ?
                             commentRepository.findById(commentRequestDto.getParentId()).orElseThrow(
-                                    () -> new CustomException(ErrorCode.POST_NOT_FOUND)
+                                    () -> new CustomException(ErrorCode.COMMENT_NOT_FOUND)
                             ) : null, LocalDateTime.now())
         );
                         return CommentResponseDto.convertCommentToDto(comment);
@@ -54,7 +54,7 @@ public class CommentService {
     @Transactional
     public void deleteComment(Long commentId) {
         Comment comment = commentRepository.findCommentByIdWithParent(commentId).orElseThrow(
-                () -> new CustomException(ErrorCode.POST_NOT_FOUND)
+                () -> new CustomException(ErrorCode.COMMENT_NOT_FOUND)
         );
         if(comment.getChildren().size() != 0) {
             comment.changeDeletedStatus(DeleteStatus.Y);

--- a/board-service/src/main/java/com/wesell/boardservice/service/PostService.java
+++ b/board-service/src/main/java/com/wesell/boardservice/service/PostService.java
@@ -2,6 +2,7 @@ package com.wesell.boardservice.service;
 
 import com.wesell.boardservice.domain.dto.reponse.PostResponseDto;
 import com.wesell.boardservice.domain.dto.request.PostRequestDto;
+import com.wesell.boardservice.domain.dto.request.PostUpdateRequestDto;
 import com.wesell.boardservice.domain.entity.Board;
 import com.wesell.boardservice.domain.entity.Comment;
 import com.wesell.boardservice.domain.entity.Post;
@@ -52,7 +53,7 @@ public class PostService {
                 () -> new CustomException(ErrorCode.POST_NOT_FOUND)
         );
         List<Comment> comments = commentRepository.findCommentByPostId(post.getId()).orElseThrow(
-                () -> new CustomException(ErrorCode.POST_NOT_FOUND)
+                () -> new CustomException(ErrorCode.COMMENT_NOT_FOUND)
         );
 
         post.addClick();
@@ -62,5 +63,24 @@ public class PostService {
                 .comments(comments)
                 .click(post.getClick())
                 .build();
+    }
+
+    // 게시글 삭제 로직
+    public void deletePost(Long postId) {
+        Post post = postRepository.findById(postId).orElseThrow(
+                () -> new CustomException(ErrorCode.POST_NOT_FOUND)
+        );
+        postRepository.deleteById(post.getId());
+    }
+
+    // 게시글 수정 로직
+    public void updatePost(PostUpdateRequestDto postUpdateRequestDto, Long postId) {
+        Post post = postRepository.findById(postId).orElseThrow(
+                () -> new CustomException(ErrorCode.POST_NOT_FOUND)
+        );
+
+        post.updateTitle(postUpdateRequestDto.getTitle());
+        post.updateContent(postUpdateRequestDto.getContent());
+        postRepository.save(post);
     }
 }


### PR DESCRIPTION
* Redis 성능 테스트 및 게시물 삭제, 수정 로직 추가

- 게시물 삭제, 수정 로직 및 에러코드 추가하였습니다.

- Redis 성능 테스트 완료

- 캐시를 붙인 서비스와 붙이지 않은 서비스를 각각 다른 컨트롤러에서 호출하여 테스트를 진행하였습니다~

![db](https://github.com/playdata-final-project-team/Wesell/assets/138194791/4eb29de6-ded1-4e15-ad5e-e72eae2ff19e)
초당 50번의 요청을 100번 반복 시 DB조회속도는 평균 102ms

![redis](https://github.com/playdata-final-project-team/Wesell/assets/138194791/2bb883ed-7830-420c-ae53-cc1dfab3df86)
마찬가지로 같은 조건으로 요청을 반복 시 Redis Cache를 통한 조회속도는 평균 42ms로 2배이상빠른것을 볼 수 있습니다.

- 최대응답속도, 최소응답속도도 차이나는 것을 보아, 요청이 많아질수록 평균응답속도는 redis를 사용하는것이 훨씬 효율적임을 알 수 있습니다

- 이외에도 수정사항이나 추가사항있으면 댓글 바랍니다~