### PR TITLE
fix: 조회수 오류 및 댓글 중복 오류 관련 처리

### DIFF
--- a/board-service/src/main/java/com/wesell/boardservice/controller/CommentController.java
+++ b/board-service/src/main/java/com/wesell/boardservice/controller/CommentController.java
@@ -16,17 +16,17 @@ import java.util.List;
 public class CommentController {
 
     private final CommentService commentService;
-
+    // 댓글 조회
     @GetMapping("/comments/{postId}")
     public ResponseEntity<List<CommentResponseDto>> findAllCommentsByPostId(@PathVariable("postId") Long postId) {
         return ResponseEntity.ok(commentService.findCommentsByPostId(postId));
     }
-
+    // 댓글 생성
     @PostMapping("/comments")
     public ResponseEntity<CommentResponseDto> createComment(@RequestBody CommentRequestDto commentRequestDto) {
         return ResponseEntity.ok(commentService.createComment(commentRequestDto));
     }
-
+    // 댓글 삭제
     @DeleteMapping("/comments/{commentId}")
     public void deleteComment(@PathVariable("commentId") Long commentId) {
         commentService.deleteComment(commentId);

--- a/board-service/src/main/java/com/wesell/boardservice/domain/repository/CommentRepositoryImpl.java
+++ b/board-service/src/main/java/com/wesell/boardservice/domain/repository/CommentRepositoryImpl.java
@@ -14,11 +14,27 @@ public class CommentRepositoryImpl implements CustomCommentRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
+    public Optional<List<Comment>> findCommentByPostIdAndParentIsNull(Long postId) {
+        List<Comment> comments = queryFactory.selectFrom(comment)
+                .leftJoin(comment.parent)
+                .fetchJoin()
+                .where (comment.post.id.eq(postId),
+                        comment.parent.isNull()        //parentId가 null인 경우만 필터링
+                )
+                .orderBy(
+                        comment.parent.id.asc().nullsFirst(),
+                        comment.createdAt.asc()
+                ).fetch();
+
+        return Optional.ofNullable(comments);
+    }
+
+    @Override
     public Optional<List<Comment>> findCommentByPostId(Long postId) {
         List<Comment> comments = queryFactory.selectFrom(comment)
                 .leftJoin(comment.parent)
                 .fetchJoin()
-                .where(comment.post.id.eq(postId))
+                .where (comment.post.id.eq(postId))
                 .orderBy(
                         comment.parent.id.asc().nullsFirst(),
                         comment.createdAt.asc()

--- a/board-service/src/main/java/com/wesell/boardservice/domain/repository/CustomCommentRepository.java
+++ b/board-service/src/main/java/com/wesell/boardservice/domain/repository/CustomCommentRepository.java
@@ -6,5 +6,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface CustomCommentRepository {
+    Optional<List<Comment>> findCommentByPostIdAndParentIsNull(Long postId);
+
     Optional<List<Comment>> findCommentByPostId(Long postId);
 }

--- a/board-service/src/main/java/com/wesell/boardservice/error/ErrorCode.java
+++ b/board-service/src/main/java/com/wesell/boardservice/error/ErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "400", "존재하지 않는 게시물입니다."),
-    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "400", "댓글을 찾을 수 없습니다.");
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "400", "댓글을 찾을 수 없습니다."),
+    FEIGN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "서버가 다운되었습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/board-service/src/main/java/com/wesell/boardservice/feignClient/UserFeignClient.java
+++ b/board-service/src/main/java/com/wesell/boardservice/feignClient/UserFeignClient.java
@@ -5,10 +5,11 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(name = "user-service")
 public interface UserFeignClient {
     @PostMapping("api/v2/FindNickName")
-    String findNicknameByUuid(String uuid);
+    String findNicknameByUuid(@RequestBody String uuid);
 
 }


### PR DESCRIPTION
- BoardService에 발생했던 오류 처리 완료하였습니다.

- 첫번째 발생했던 에러는 조회수가 증가하지 않는 오류였는데 @transactional로 서비스 메서드를 트랜잭션 처리를 해주었는데 조회수가 증가하였습니다. 이유로는 제가 생각하기에 메서드안에 메서드를 호출해서 조회수 증가 메서드로 인한 변경이 트랜잭션 커밋시점에 데이터베이스에 반영되야 되서? 라고 생각합니다. 정확한 이유아시면 댓글 부탁 바랍니다~

- 두번째 에러는 댓글 중복 문제였는데 댓글, 대댓글을 조회할 때, 대댓글도 독립적으로 따로 또 조회되는 문제를 querydsl에 where부분에 parentId가 null인 경우의 조건을 포함해서 문제를 해결하였습니다. 여기서 발생하는 문제가 있었는데 게시물과 댓글을 함께 조회할때는 parentId가 null일때를 조회해야지 올바르게 값이 나오고 댓글만 조회할때는 원래 방법으로 해야지만 값이 올바르게 나와서 기존쿼리메서드는 삭제하지 않고 댓글만 조회할 때 사용하고 있습니다.

- 이외에도 수정사항이나 추가할 사항 있으면 댓글 바랍니다~