### PR TITLE
feat: 게시글 상세 페이지 및 수정 페이지 구현 & 게시글 삭제 구

### DIFF
--- a/board-service/src/main/java/com/wesell/boardservice/domain/dto/reponse/PostResponseDto.java
+++ b/board-service/src/main/java/com/wesell/boardservice/domain/dto/reponse/PostResponseDto.java
@@ -11,7 +11,10 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostResponseDto implements Serializable {
+    private String boardTitle;
     private String title;
+    private String writer;
+    private String createdAt;
     private String content;
     private Long click;
     private List<Comment> comments;

--- a/board-service/src/main/java/com/wesell/boardservice/domain/entity/Post.java
+++ b/board-service/src/main/java/com/wesell/boardservice/domain/entity/Post.java
@@ -37,7 +37,7 @@ public class Post {
     @Column(name = "p_click", nullable = false)
     private Long click;
 
-    @Column(name = "p_content", nullable = false)
+    @Column(columnDefinition = "TEXT",name = "p_content", nullable = false)
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/board-service/src/main/java/com/wesell/boardservice/service/CommentService.java
+++ b/board-service/src/main/java/com/wesell/boardservice/service/CommentService.java
@@ -62,15 +62,9 @@ public class CommentService {
             commentRepository.delete(getDeleteAncestorComment(comment));
         }
     }
-    // 부모 댓글 삭제 로직
-    private Comment getDeleteAncestorComment(Comment comment) {
-        Comment parent = comment.getParent();
-        if(parent != null && parent.getChildren().size() == 1 && parent.getIsDeleted() == DeleteStatus.Y)
-            return getDeleteAncestorComment(parent);
-        return comment;
-    }
+
     // 대댓글 중첩 구조로 변환하는 로직
-    private List<CommentResponseDto> convertNestedStructure(List<Comment> comments) {
+    public List<CommentResponseDto> convertNestedStructure(List<Comment> comments) {
         List<CommentResponseDto> result = new ArrayList<>();
         Map<Long, CommentResponseDto> map = new HashMap<>();
         comments.stream().forEach(c -> {
@@ -82,5 +76,13 @@ public class CommentService {
                 result.add(dto);
         });
         return result;
+    }
+
+    // 부모 댓글 삭제 로직
+    private Comment getDeleteAncestorComment(Comment comment) {
+        Comment parent = comment.getParent();
+        if(parent != null && parent.getChildren().size() == 1 && parent.getIsDeleted() == DeleteStatus.Y)
+            return getDeleteAncestorComment(parent);
+        return comment;
     }
 }

--- a/board-service/src/main/java/com/wesell/boardservice/service/PostService.java
+++ b/board-service/src/main/java/com/wesell/boardservice/service/PostService.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @Service
@@ -68,8 +69,11 @@ public class PostService {
 
         post.addClick();
         return PostResponseDto.builder()
+                .boardTitle(post.getBoard().getTitle())
                 .title(post.getTitle())
+                .writer(post.getWriter())
                 .content(post.getContent())
+                .createdAt(post.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
                 .comments(comments)
                 .click(post.getClick())
                 .build();

--- a/front-server/src/App.tsx
+++ b/front-server/src/App.tsx
@@ -34,6 +34,7 @@ import LoginPage from 'pages/Notification/login';
 import Kakao from 'pages/Social/kakao';
 import MainBoard from 'pages/Post/main';
 import PostWrite from 'pages/Post/write';
+import PostDetail from 'pages/Post/detail';
 
 // component: Application 컴포넌트 //
 function App() {
@@ -66,6 +67,7 @@ function App() {
         <Route path={NOTIFICATION_LOGIN_PATH()} element={<LoginPage />} />
         <Route path="/board/:boardId" element={<MainBoard></MainBoard>}></Route>
         <Route path="/board/:boardId/write" element={<PostWrite></PostWrite>}></Route>
+        <Route path="/board/:boardId/:postId" element={<PostDetail></PostDetail>}></Route>
         <Route path="*" element={<h1>404 NOT FOUND</h1>} />
       </Route>
 

--- a/front-server/src/App.tsx
+++ b/front-server/src/App.tsx
@@ -35,6 +35,7 @@ import Kakao from 'pages/Social/kakao';
 import MainBoard from 'pages/Post/main';
 import PostWrite from 'pages/Post/write';
 import PostDetail from 'pages/Post/detail';
+import PostUpdate from 'pages/Post/update';
 
 // component: Application 컴포넌트 //
 function App() {
@@ -66,8 +67,9 @@ function App() {
         <Route path={NOTIFICATION_MAIN_PATH()} element={<IndexPage />} />
         <Route path={NOTIFICATION_LOGIN_PATH()} element={<LoginPage />} />
         <Route path="/board/:boardId" element={<MainBoard></MainBoard>}></Route>
-        <Route path="/board/:boardId/write" element={<PostWrite></PostWrite>}></Route>
-        <Route path="/board/:boardId/:postId" element={<PostDetail></PostDetail>}></Route>
+        <Route path="/post/:boardId/write" element={<PostWrite></PostWrite>}></Route>
+        <Route path="/post/:boardId/:postId" element={<PostDetail></PostDetail>}></Route>
+        <Route path="/post/:boardId/:postId/update" element={<PostUpdate></PostUpdate>}></Route>
         <Route path="*" element={<h1>404 NOT FOUND</h1>} />
       </Route>
 

--- a/front-server/src/components/PostList/index.tsx
+++ b/front-server/src/components/PostList/index.tsx
@@ -29,7 +29,7 @@ const PostList = (props: Props) => {
               <td
                 id="link-to-detail"
                 onClick={(e) => {
-                  navigator(`/board/${boardId}/${post.id}`);
+                  navigator(`/post/${boardId}/${post.id}`);
                   e.currentTarget.classList.add('visited');
                 }}
               >

--- a/front-server/src/components/PostList/index.tsx
+++ b/front-server/src/components/PostList/index.tsx
@@ -1,12 +1,14 @@
 import PostListItem from 'types/interface/post-list-item';
 import './style.css';
-
+import { useNavigate } from 'react-router-dom';
 interface Props {
   posts: PostListItem[];
+  boardId: string | undefined;
 }
 
 const PostList = (props: Props) => {
-  const { posts } = props;
+  const { posts, boardId } = props;
+  const navigator = useNavigate();
   return (
     <div className="post-list-box">
       <table className="post-list">
@@ -24,7 +26,15 @@ const PostList = (props: Props) => {
           {posts.map((post, index) => (
             <tr className="post-list-tbody" key={index}>
               <td>{post.id}</td>
-              <td>{post.title}</td>
+              <td
+                id="link-to-detail"
+                onClick={(e) => {
+                  navigator(`/board/${boardId}/${post.id}`);
+                  e.currentTarget.classList.add('visited');
+                }}
+              >
+                {post.title}
+              </td>
               <td>{post.writer}</td>
               <td>{post.click}</td>
               <td>{post.createdAt}</td>

--- a/front-server/src/components/PostList/style.css
+++ b/front-server/src/components/PostList/style.css
@@ -25,3 +25,15 @@
   margin: 0;
   text-align: center;
 }
+
+#link-to-detail {
+  cursor: pointer;
+}
+
+#link-to-detail:hover {
+  color: rgb(51, 0, 255);
+}
+
+.visited {
+  color: red;
+}

--- a/front-server/src/components/Quill/Detail/index.tsx
+++ b/front-server/src/components/Quill/Detail/index.tsx
@@ -1,0 +1,30 @@
+import { Box } from '@mui/material';
+import ReactQuill from 'react-quill';
+import 'react-quill/dist/quill.snow.css';
+
+interface Props {
+  // useRef를 사용하여 생성된 ref 객체가 되어야 하기 때문에, MutableRefObject 타입이다.
+  htmlContent: string;
+}
+
+// eslint-disable-next-line react/display-name
+const TextEditor = (props: Props) => {
+  const { htmlContent } = props;
+  return (
+    <Box>
+      <ReactQuill
+        readOnly={true}
+        value={htmlContent}
+        theme="bubble"
+        style={{
+          border: 'solid 1px #c0c0c0',
+          height: '400px',
+          margin: '10px 0px 50px 0px',
+          padding: '10px',
+        }} // style
+      />
+    </Box>
+  );
+};
+
+export default TextEditor;

--- a/front-server/src/components/Quill/Write/index.tsx
+++ b/front-server/src/components/Quill/Write/index.tsx
@@ -7,7 +7,7 @@ interface Props {
   // useRef를 사용하여 생성된 ref 객체가 되어야 하기 때문에, MutableRefObject 타입이다.
   quillRef: MutableRefObject<ReactQuill | null>;
   htmlContent: string;
-  setHtmlContent: (content: string) => void;
+  setHtmlContent?: (content: string) => void;
 }
 
 // eslint-disable-next-line react/display-name

--- a/front-server/src/pages/Post/detail/index.tsx
+++ b/front-server/src/pages/Post/detail/index.tsx
@@ -1,0 +1,101 @@
+import { useNavigate, useParams } from 'react-router-dom';
+import './style.css';
+import axios from 'axios';
+import { useEffect, useRef, useState } from 'react';
+import TextEditor from 'components/Quill/Detail';
+
+interface postDetail {
+  boardTitle: string;
+  title: string;
+  content: string;
+  click: number;
+  writer: string;
+  createdAt: string;
+  comments: {
+    writer: string;
+    content: string;
+    createdAt: string;
+  }[];
+}
+
+const PostDetail = () => {
+  const navigator = useNavigate();
+  const { boardId, postId } = useParams();
+
+  // state: 게시판 제목 //
+  const [boardTitle, setBoardTitle] = useState<string>('');
+
+  // state: 게시글 제목 //
+  const [title, setTitle] = useState<string>('');
+
+  // state: 게시글 내용 //
+  const [content, setContent] = useState<string>('');
+
+  // state: 작성자 //
+  const [writer, setWriter] = useState<string>('');
+
+  // state: 생성일자 //
+  const [createdAt, setCreatedAt] = useState<string>('');
+
+  // state: 게시글 조회수 //
+  const [click, setClick] = useState<number>(0);
+
+  // function: 게시글 상세 정보 조회 함수 //
+  const fetchPost = async () => {
+    try {
+      const response = await axios.get(`/board-service/api/v1/post/${postId}`);
+      const responseData = response.data as postDetail;
+      const { boardTitle, title, content, click, createdAt, writer } = responseData;
+      setBoardTitle(boardTitle);
+      setTitle(title);
+      setContent(content);
+      setClick(click);
+      setCreatedAt(createdAt);
+      setWriter(writer);
+    } catch (error) {
+      console.error('⚠️ 게시글 조회 시 오류 발생', error);
+    }
+  };
+
+  useEffect(() => {
+    fetchPost();
+  }, []);
+
+  return (
+    <div className="post-detail-wrapper">
+      <div className="post-detail-container">
+        <h2 className="board-title">{boardTitle}</h2>
+        <div className="post-detail-top">
+          <div className="post-title">{title}</div>
+          <div className="post-detail-box">
+            <div className="post-detail-box-right">
+              <p>{writer}</p>
+              <p>|</p>
+              <p>{createdAt}</p>
+            </div>
+            <div className="post-detail-box-left">
+              <p>조회 {click}</p>
+              <p>|</p>
+              <p>댓글</p>
+            </div>
+          </div>
+        </div>
+        <TextEditor htmlContent={content} />
+        <div className="post-detail-btns">
+          <button
+            className="post-list-btn"
+            onClick={() => {
+              navigator(`/board/${boardId}`);
+            }}
+          >
+            목록
+          </button>
+          <button className="post-update-btn">수정</button>
+          <button className="post-delete-btn">삭제</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PostDetail;

--- a/front-server/src/pages/Post/detail/index.tsx
+++ b/front-server/src/pages/Post/detail/index.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useParams } from 'react-router-dom';
 import './style.css';
 import axios from 'axios';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import TextEditor from 'components/Quill/Detail';
 
 interface postDetail {
@@ -39,6 +39,27 @@ const PostDetail = () => {
 
   // state: 게시글 조회수 //
   const [click, setClick] = useState<number>(0);
+
+  // comment: 수정 + 삭제 관련 - 해당 회원만 삭제 수정이 가능하도록 로직 수정 예정 //
+  // event-handler: 게시글 수정 버튼 핸들러 //
+
+  // event-handler: 게시글 삭제 버튼 핸들러 //
+  const onPostDeleteBtnHandler = async () => {
+    if (confirm('정말로 게시글을 삭제하시겠습니까?')) {
+      try {
+        const response = await axios.delete(`/board-service/api/v1/post/delete/${postId}`);
+        const message = response.data;
+        alert(`😀 ${message}`);
+        navigator(`/board/${boardId}`);
+      } catch (error) {
+        console.log(error);
+        alert('😒 게시글 삭제 실패');
+        return;
+      }
+    } else {
+      return;
+    }
+  };
 
   // function: 게시글 상세 정보 조회 함수 //
   const fetchPost = async () => {
@@ -90,8 +111,17 @@ const PostDetail = () => {
           >
             목록
           </button>
-          <button className="post-update-btn">수정</button>
-          <button className="post-delete-btn">삭제</button>
+          <button
+            className="post-update-btn"
+            onClick={() => {
+              navigator(`/post/${boardId}/${postId}/update`);
+            }}
+          >
+            수정
+          </button>
+          <button className="post-delete-btn" onClick={onPostDeleteBtnHandler}>
+            삭제
+          </button>
         </div>
       </div>
     </div>

--- a/front-server/src/pages/Post/detail/style.css
+++ b/front-server/src/pages/Post/detail/style.css
@@ -1,0 +1,91 @@
+.post-detail-wrapper {
+  width: 100%;
+  height: 100%;
+}
+
+.post-detail-container {
+  min-height: 700px;
+  max-width: 1024px;
+  width: 100%;
+  margin: 0 auto;
+
+  display: flex;
+  flex-direction: column;
+}
+
+.post-detail-top {
+  border: solid 1px #c0c0c0;
+  padding: 10px;
+}
+
+.post-title {
+  font-size: 1.2rem;
+}
+
+.post-detail-box {
+  display: flex;
+  justify-content: space-between;
+}
+
+.post-detail-box-right {
+  display: flex;
+}
+
+.post-detail-box-right p {
+  margin: 3px;
+}
+
+.post-detail-box-left {
+  display: flex;
+}
+
+.post-detail-box-left p {
+  margin: 3px;
+}
+
+/* .post-content {
+  margin: 10px 0px 50px 0px;
+  height: 400px;
+  border: solid 1px #c0c0c0;
+  padding: 10px;
+} */
+
+.post-detail-btns {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.post-detail-btns button {
+  width: 100px;
+  margin: 5px;
+  font-size: 15px;
+  color: rgba(255, 255, 255, 0.8);
+  border: none;
+  border-radius: 5px;
+  padding: 8px 20px;
+  cursor: pointer;
+}
+
+.post-list-btn {
+  background-color: #7c7c7c;
+}
+
+.post-list-btn:active {
+  background-color: #515151;
+}
+
+.post-update-btn {
+  background-color: #b2aeae;
+}
+
+.post-update-btn:active {
+  background-color: #8d7e7e;
+}
+
+.post-delete-btn {
+  background-color: #e85163;
+}
+
+.post-delete-btn:active {
+  background-color: #e93449;
+}

--- a/front-server/src/pages/Post/main/index.tsx
+++ b/front-server/src/pages/Post/main/index.tsx
@@ -96,7 +96,7 @@ const MainBoard = () => {
     <div className="main-board-wrapper">
       <div className="main-board-container">
         <h2 className="board-title">{title}</h2>
-        <PostList posts={posts} />
+        <PostList posts={posts} boardId={boardId} />
         <div className="main-board-under-bar">
           <div className="main-board-pagination">
             {totalPages !== 0 && (

--- a/front-server/src/pages/Post/main/index.tsx
+++ b/front-server/src/pages/Post/main/index.tsx
@@ -126,7 +126,7 @@ const MainBoard = () => {
           className="main-board-btn"
           type="button"
           onClick={() => {
-            navigator(`/board/${boardId}/write`);
+            navigator(`/post/${boardId}/write`);
           }}
         >
           글등록

--- a/front-server/src/pages/Post/update/index.tsx
+++ b/front-server/src/pages/Post/update/index.tsx
@@ -1,0 +1,102 @@
+import TextEditor from 'components/Quill/Write';
+import './style.css';
+import { useEffect, useRef, useState } from 'react';
+import axios from 'axios';
+import { useNavigate, useParams } from 'react-router-dom';
+
+interface postDetail {
+  boardTitle: string;
+  title: string;
+  content: string;
+}
+
+const PostUpdate = () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const quillRef: any = useRef();
+
+  const { postId, boardId } = useParams();
+
+  const navigator = useNavigate();
+
+  const uuid = sessionStorage.getItem('uuid'); // 로그인 회원 uuid
+
+  // state: 게시판 제목 //
+  const [boardTitle, setBoardTitle] = useState<string>('');
+
+  // state: 게시글 내용 //
+  const [htmlContent, setHtmlContent] = useState<string>('');
+
+  // state: 게시글 제목 //
+  const [title, setTitle] = useState<string>('');
+
+  // event-handler: 수정 버튼 핸들러 //
+  const RegisterBtnHandler = async () => {
+    const request = {
+      title: title,
+      content: htmlContent,
+    };
+    //axios 요청
+    try {
+      const response = await axios.put(`/board-service/api/v1/post/update/${postId}`, request);
+      const message = response.data;
+      alert(`😀 ${message}`);
+      navigator(`/post/${boardId}/${postId}`);
+    } catch (error) {
+      alert('😒 게시글 수정 실패');
+    }
+  };
+
+  // function: 게시글 상세 정보 조회 함수 //
+  const fetchPost = async () => {
+    try {
+      const response = await axios.get(`/board-service/api/v1/post/${postId}`);
+      const responseData = response.data as postDetail;
+      const { boardTitle, title, content } = responseData;
+      setBoardTitle(boardTitle);
+      setTitle(title);
+      setHtmlContent(content);
+    } catch (error) {
+      console.error('⚠️ 게시글 조회 시 오류 발생', error);
+    }
+  };
+
+  useEffect(() => {
+    fetchPost();
+  }, []);
+
+  return (
+    <div className="post-write-wrapper">
+      <div className="post-write-container">
+        <h2 className="board-title">{boardTitle}</h2>
+
+        <div className="post-write-title">
+          <input value={title} onChange={(event) => setTitle(event.target.value)} />
+        </div>
+
+        <div className="post-write-content">
+          <TextEditor
+            quillRef={quillRef}
+            htmlContent={htmlContent}
+            setHtmlContent={setHtmlContent}
+          ></TextEditor>
+        </div>
+
+        <div className="post-write-btns">
+          <button
+            className="post-write-cancel-btn"
+            onClick={() => {
+              navigator(`/post/${boardId}/${postId}`);
+            }}
+          >
+            취소
+          </button>
+          <button className="post-write-ok-btn" onClick={RegisterBtnHandler}>
+            수정
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PostUpdate;

--- a/front-server/src/pages/Post/write/index.tsx
+++ b/front-server/src/pages/Post/write/index.tsx
@@ -1,4 +1,4 @@
-import TextEditor from 'components/TextEditor';
+import TextEditor from 'components/Quill/Write';
 import './style.css';
 import { useRef, useState } from 'react';
 import axios from 'axios';


### PR DESCRIPTION
## 게시글 상세

![image](https://github.com/playdata-final-project-team/Wesell/assets/118423671/bcbdca9b-372c-41b1-9739-790d439748c3)

- 게시글 상세 정보 조회 기능 구현 완료

<br>

## 게시글 수정
![image](https://github.com/playdata-final-project-team/Wesell/assets/118423671/f05b55af-79a7-4169-acff-5d6750675dae)

- 게시글 수정 구현 완료

<br>

## 게시글 삭제
![image](https://github.com/playdata-final-project-team/Wesell/assets/118423671/8a4a0cd0-287a-4027-a55c-86a8c0b740b8)

- confirm 메시지 확인 후 삭제하도록 구현 완료.

<br>

## 👀 문제점
- 게시글 수정, 삭제 작성자만 접근 가능하도록 로직 수정 필요.
