### PR TITLE
feat: 게시글 대댓글 페이지 구현

### DIFF
--- a/board-service/src/main/java/com/wesell/boardservice/controller/CommentController.java
+++ b/board-service/src/main/java/com/wesell/boardservice/controller/CommentController.java
@@ -1,6 +1,7 @@
 package com.wesell.boardservice.controller;
 
 import com.wesell.boardservice.domain.dto.reponse.CommentResponseDto;
+import com.wesell.boardservice.domain.dto.reponse.PageResponseDto;
 import com.wesell.boardservice.domain.dto.request.CommentRequestDto;
 import com.wesell.boardservice.domain.entity.Comment;
 import com.wesell.boardservice.service.CommentService;
@@ -18,8 +19,10 @@ public class CommentController {
     private final CommentService commentService;
     // 댓글 조회
     @GetMapping("/comments/{postId}")
-    public ResponseEntity<List<CommentResponseDto>> findAllCommentsByPostId(@PathVariable("postId") Long postId) {
-        return ResponseEntity.ok(commentService.findCommentsByPostId(postId));
+    public ResponseEntity<?> findAllCommentsByPostId(@RequestParam(name = "page", defaultValue = "0") Integer page,
+                                                                         @RequestParam(name = "size", defaultValue = "10") int size,
+                                                                         @PathVariable("postId") Long postId) {
+        return ResponseEntity.ok(commentService.findCommentsWithPage(postId, page, size));
     }
     // 댓글 생성
     @PostMapping("/comments")
@@ -28,7 +31,8 @@ public class CommentController {
     }
     // 댓글 삭제
     @DeleteMapping("/comments/{commentId}")
-    public void deleteComment(@PathVariable("commentId") Long commentId) {
+    public ResponseEntity<?> deleteComment(@PathVariable("commentId") Long commentId) {
         commentService.deleteComment(commentId);
+        return ResponseEntity.ok("댓글이 삭제되었습니다.");
     }
 }

--- a/board-service/src/main/java/com/wesell/boardservice/domain/dto/reponse/CommentResponseDto.java
+++ b/board-service/src/main/java/com/wesell/boardservice/domain/dto/reponse/CommentResponseDto.java
@@ -26,6 +26,10 @@ public class CommentResponseDto {
         this.createdAt = createdAt;
     }
 
+    public void addChildren(CommentResponseDto child){
+        this.children.add(child);
+    }
+
     public static CommentResponseDto convertCommentToDto(Comment comment) {
         return comment.getIsDeleted() == DeleteStatus.Y ?
                 new CommentResponseDto(comment.getId(), "삭제된 댓글입니다.", null, comment.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))) :

--- a/board-service/src/main/java/com/wesell/boardservice/domain/dto/reponse/PageResponseDto.java
+++ b/board-service/src/main/java/com/wesell/boardservice/domain/dto/reponse/PageResponseDto.java
@@ -17,6 +17,5 @@ public class PageResponseDto implements Serializable {
     private int page;
     private long totalElements;
     private int size;
-
     private long totalPages;
 }

--- a/board-service/src/main/java/com/wesell/boardservice/domain/dto/reponse/PostResponseDto.java
+++ b/board-service/src/main/java/com/wesell/boardservice/domain/dto/reponse/PostResponseDto.java
@@ -17,5 +17,5 @@ public class PostResponseDto implements Serializable {
     private String createdAt;
     private String content;
     private Long click;
-    private List<Comment> comments;
+    private List<CommentResponseDto> comments;
 }

--- a/board-service/src/main/java/com/wesell/boardservice/domain/repository/CommentRepository.java
+++ b/board-service/src/main/java/com/wesell/boardservice/domain/repository/CommentRepository.java
@@ -1,6 +1,8 @@
 package com.wesell.boardservice.domain.repository;
 
 import com.wesell.boardservice.domain.entity.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -8,6 +10,9 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long>, CustomCommentRepository {
+
+    @Query("select c from Comment c where c.post.id = :postId order by c.createdAt asc")
+    Page<Comment> findAllByPostId(@Param("postId") Long postId, Pageable pageable);
 
     @Query("select c from Comment c left join fetch c.parent where c.id = :id")
     Optional<Comment> findCommentByIdWithParent(@Param("id") Long id);

--- a/board-service/src/main/java/com/wesell/boardservice/domain/repository/CommentRepositoryImpl.java
+++ b/board-service/src/main/java/com/wesell/boardservice/domain/repository/CommentRepositoryImpl.java
@@ -39,7 +39,6 @@ public class CommentRepositoryImpl implements CustomCommentRepository {
                         comment.parent.id.asc().nullsFirst(),
                         comment.createdAt.asc()
                 ).fetch();
-
         return Optional.ofNullable(comments);
     }
 }

--- a/board-service/src/main/java/com/wesell/boardservice/service/CommentService.java
+++ b/board-service/src/main/java/com/wesell/boardservice/service/CommentService.java
@@ -1,6 +1,7 @@
 package com.wesell.boardservice.service;
 
 import com.wesell.boardservice.domain.dto.reponse.CommentResponseDto;
+import com.wesell.boardservice.domain.dto.reponse.PageResponseDto;
 import com.wesell.boardservice.domain.dto.request.CommentRequestDto;
 import com.wesell.boardservice.domain.entity.Comment;
 import com.wesell.boardservice.domain.entity.DeleteStatus;
@@ -13,26 +14,52 @@ import com.wesell.boardservice.error.exception.CustomException;
 import com.wesell.boardservice.feignClient.UserFeignClient;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 
 @Service
 @RequiredArgsConstructor
+@Log4j2
 public class CommentService {
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
-    // 댓글 조회
-    public List<CommentResponseDto> findCommentsByPostId(Long postId) {
-        postRepository.findById(postId).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
-        List<Comment> comments = commentRepository.findCommentByPostId(postId).orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
-        return convertNestedStructure(comments);
+
+    // 댓글 조회 - 페이징 처리
+    public PageResponseDto findCommentsWithPage(Long postId, int page, int size){
+
+        List<Comment> allComments = commentRepository.findAll();
+
+        Page<Comment> commentsPage = commentRepository.findAllByPostId(postId,
+                PageRequest.of(page,size, Sort.by(Sort.Order.desc("createdAt"))));
+
+        commentsPage.getContent().stream().forEach( c->
+                log.info("------------------------------------------->>>>>111" + c)
+        );
+
+        List<CommentResponseDto> comments = convertNestedStructure(commentsPage.getContent(), allComments);
+
+        comments.stream().forEach( c->
+                log.info("------------------------------------------->>>>>222" + c)
+        );
+
+        return PageResponseDto.builder()
+                .dtoList(comments)
+                .page(page)
+                .totalPages(commentsPage.getTotalPages())
+                .size(commentsPage.getSize())
+                .totalElements(commentsPage.getTotalElements())
+                .build();
     }
+
     // 댓글 저장
     @Transactional
     public CommentResponseDto createComment(CommentRequestDto commentRequestDto) {
@@ -63,19 +90,30 @@ public class CommentService {
         }
     }
 
-    // 대댓글 중첩 구조로 변환하는 로직
-    public List<CommentResponseDto> convertNestedStructure(List<Comment> comments) {
-        List<CommentResponseDto> result = new ArrayList<>();
-        Map<Long, CommentResponseDto> map = new HashMap<>();
-        comments.stream().forEach(c -> {
-            CommentResponseDto dto = CommentResponseDto.convertCommentToDto(c);
-            map.put(dto.getId(), dto);
-            if(c.getParent() != null)
-                map.get(c.getParent().getId()).getChildren().add(dto);
-            else
-                result.add(dto);
-        });
-        return result;
+    // comment -> dto 변환
+    public List<CommentResponseDto> convertNestedStructure(List<Comment> comments, List<Comment> allComments) {
+
+        Map<Long, CommentResponseDto> map= new HashMap<>();
+        
+        // map 초기화(부모 댓글들 담기)
+        comments.stream()
+                .filter(comment -> Objects.isNull(comment.getParent()))
+                .forEach(comment -> map.put(comment.getId(),CommentResponseDto.convertCommentToDto(comment)));
+
+        // 댓글에 대댓글 담기
+        allComments.stream()
+                .filter(c -> Objects.nonNull(c.getParent()))
+                .forEach(c -> {
+                    CommentResponseDto parent = map.get(c.getParent().getId());
+                    if (parent != null) {
+                        parent.addChildren(CommentResponseDto.convertCommentToDto(c));
+                    }
+                });
+
+        // map -> list 변환
+        List<CommentResponseDto> list = new ArrayList<>(map.values());
+        list.sort(Comparator.comparing(CommentResponseDto::getId));
+        return list;
     }
 
     // 부모 댓글 삭제 로직

--- a/board-service/src/main/java/com/wesell/boardservice/service/PostService.java
+++ b/board-service/src/main/java/com/wesell/boardservice/service/PostService.java
@@ -1,5 +1,6 @@
 package com.wesell.boardservice.service;
 
+import com.wesell.boardservice.domain.dto.reponse.CommentResponseDto;
 import com.wesell.boardservice.domain.dto.reponse.PostResponseDto;
 import com.wesell.boardservice.domain.dto.request.PostRequestDto;
 import com.wesell.boardservice.domain.dto.request.PostUpdateRequestDto;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -67,6 +69,9 @@ public class PostService {
                 () -> new CustomException(ErrorCode.COMMENT_NOT_FOUND)
         );
 
+        List<CommentResponseDto> commentList = comments.stream().map(CommentResponseDto::convertCommentToDto
+        ).toList();
+
         post.addClick();
         return PostResponseDto.builder()
                 .boardTitle(post.getBoard().getTitle())
@@ -74,7 +79,7 @@ public class PostService {
                 .writer(post.getWriter())
                 .content(post.getContent())
                 .createdAt(post.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
-                .comments(comments)
+                .comments(commentList)
                 .click(post.getClick())
                 .build();
     }

--- a/front-server/src/App.tsx
+++ b/front-server/src/App.tsx
@@ -36,6 +36,7 @@ import MainBoard from 'pages/Post/main';
 import PostWrite from 'pages/Post/write';
 import PostDetail from 'pages/Post/detail';
 import PostUpdate from 'pages/Post/update';
+import CommentList from 'components/CommentList';
 
 // component: Application 컴포넌트 //
 function App() {
@@ -76,6 +77,7 @@ function App() {
       {/* 테스트 라우터 */}
       <Route>
         <Route path="/test/detail/:productId" element={<TestDetailPage />} />
+        <Route path="/test/comment/list" element={<CommentList />} />
       </Route>
     </Routes>
   );

--- a/front-server/src/apis/index.ts
+++ b/front-server/src/apis/index.ts
@@ -305,6 +305,19 @@ export const loadChatRoomListRequest = async (uuid: string | null) => {
   }
 };
 
+// 닉네임 조회
+export const getNicknameRequest = async (uuid: string) => {
+  try {
+    const response = await axios.get(`/user-service/api/v1/${uuid}/nickname`);
+    return response.data;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (error: any) {
+    if (!error.response) return null;
+    const responseBody: ResponseDto = error.response.data;
+    return responseBody;
+  }
+};
+
 // comment: *중요 - 순환참조로 인해 Interceptor 내부에서 axios 요청 금지
 axios.interceptors.response.use(
   (res) => res,

--- a/front-server/src/components/CommentItem/index.tsx
+++ b/front-server/src/components/CommentItem/index.tsx
@@ -1,0 +1,124 @@
+import axios from 'axios';
+import './style.css';
+import { Comment } from 'types/interface';
+import { useState } from 'react';
+import { FaPlusSquare } from 'react-icons/fa';
+import { FaSquareMinus } from 'react-icons/fa6';
+
+interface Props {
+  parentComment?: Comment;
+  childComment?: Comment;
+  postId?: number;
+}
+
+const CommentItem = (props: Props) => {
+  const { childComment, parentComment, postId } = props;
+
+  const [content, setContent] = useState<string>('');
+
+  const [isVisible, setIsVisible] = useState<boolean>(false);
+
+  // event-handler: 게시글 삭제 버튼 핸들러 //
+  const onPostDeleteBtnHandler = async () => {
+    if (confirm('정말로 게시글을 삭제하시겠습니까?')) {
+      try {
+        const response = await axios.delete(
+          `/board-service/api/v1/comments/${parentComment?.id || childComment?.id}`,
+        );
+        const message = response.data;
+        alert(`😀 ${message}`);
+        return;
+      } catch (error) {
+        console.log(error);
+        alert('😒 댓글 삭제 실패');
+        return;
+      }
+    } else {
+      return;
+    }
+  };
+
+  // event-handler: 대댓글 등록 버튼 핸들러 //
+  const onAddCommentEventHandler = async () => {
+    try {
+      const request = {
+        postId: 102,
+        parentId: parentComment?.id,
+        content: content,
+        writer: '작성자',
+      };
+      await axios.post('/board-service/api/v1/comments', request);
+      setContent('');
+      return;
+    } catch (error) {
+      console.log(error);
+      alert('😒 댓글 삭제 실패');
+      return;
+    }
+  };
+
+  return (
+    <div className="comment-item-box">
+      {parentComment && (
+        <>
+          <div className="parent-comment">
+            <div className="comment-writer">
+              <span>{parentComment.writer}</span>
+            </div>
+            <div className="comment-content">
+              <p>{parentComment.content}</p>
+            </div>
+            <div className="comment-write-date">
+              <span>{parentComment.createdAt}</span>
+            </div>
+            <button className="delete-btn" onClick={onPostDeleteBtnHandler}>
+              X
+            </button>
+          </div>
+          <div className="comment-comment">
+            <div className="reply-box-toggle" onClick={() => setIsVisible((prev) => !prev)}>
+              {isVisible ? (
+                <>
+                  <FaSquareMinus style={{ fontSize: '12px' }} />
+                  <div>숨기기</div>
+                </>
+              ) : (
+                <>
+                  <FaPlusSquare style={{ fontSize: '12px' }} />
+                  <div>답글 달기</div>
+                </>
+              )}
+            </div>
+            <div className={`reply-box ${isVisible ? 'visible' : ''}`}>
+              <textarea
+                placeholder="욕설이나 폭언은 자제 부탁드립니다."
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+              ></textarea>
+              <button onClick={onAddCommentEventHandler}>등록</button>
+            </div>
+          </div>
+        </>
+      )}
+      {childComment && (
+        <div className="child-comment">
+          <div className="comment-writer">
+            <span>{childComment.writer}</span>
+          </div>
+          <div className="comment-content">
+            <span>ㄴ</span>
+            <p>{childComment.content}</p>
+          </div>
+          <div className="comment-write-date">
+            <span>{childComment.createdAt}</span>
+          </div>
+          <button className="delete-btn" onClick={onPostDeleteBtnHandler}>
+            X
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CommentItem;

--- a/front-server/src/components/CommentItem/index.tsx
+++ b/front-server/src/components/CommentItem/index.tsx
@@ -1,25 +1,45 @@
 import axios from 'axios';
 import './style.css';
 import { Comment } from 'types/interface';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { FaPlusSquare } from 'react-icons/fa';
 import { FaSquareMinus } from 'react-icons/fa6';
+import { getNicknameRequest } from 'apis';
 
 interface Props {
   parentComment?: Comment;
   childComment?: Comment;
   postId?: number;
+  writer?: string;
+  fetchComments: () => void;
 }
 
 const CommentItem = (props: Props) => {
-  const { childComment, parentComment, postId } = props;
+  const { childComment, parentComment, postId, writer } = props;
+
+  const { fetchComments } = props;
 
   const [content, setContent] = useState<string>('');
 
   const [isVisible, setIsVisible] = useState<boolean>(false);
 
+  const [nickname, setNickname] = useState<string>('');
+
   // event-handler: 게시글 삭제 버튼 핸들러 //
   const onPostDeleteBtnHandler = async () => {
+    if (parentComment) {
+      if (nickname !== parentComment.writer) {
+        alert('🥹 본인이 작성한 댓글이 아닙니다.');
+        return;
+      }
+    }
+    if (childComment) {
+      if (nickname !== childComment.writer) {
+        alert('🥹 본인이 작성한 댓글이 아닙니다.');
+        return;
+      }
+    }
+
     if (confirm('정말로 게시글을 삭제하시겠습니까?')) {
       try {
         const response = await axios.delete(
@@ -27,6 +47,7 @@ const CommentItem = (props: Props) => {
         );
         const message = response.data;
         alert(`😀 ${message}`);
+        fetchComments();
         return;
       } catch (error) {
         console.log(error);
@@ -42,20 +63,36 @@ const CommentItem = (props: Props) => {
   const onAddCommentEventHandler = async () => {
     try {
       const request = {
-        postId: 102,
+        postId: postId,
         parentId: parentComment?.id,
         content: content,
-        writer: '작성자',
+        writer: writer,
       };
       await axios.post('/board-service/api/v1/comments', request);
       setContent('');
+      fetchComments();
       return;
     } catch (error) {
       console.log(error);
-      alert('😒 댓글 삭제 실패');
+      alert('😒 댓글 등록 실패');
       return;
     }
   };
+
+  useEffect(() => {
+    const fetchData = async () => {
+      console.log;
+
+      if (!writer) {
+        return;
+      }
+
+      const nickname = await getNicknameRequest(writer);
+      setNickname(nickname);
+    };
+
+    fetchData();
+  }, []);
 
   return (
     <div className="comment-item-box">

--- a/front-server/src/components/CommentItem/style.css
+++ b/front-server/src/components/CommentItem/style.css
@@ -1,0 +1,183 @@
+textarea:focus {
+  outline: none;
+}
+
+.comment-item-box {
+  width: 100%;
+  height: 100%;
+}
+
+/* comment : parent - S */
+.parent-comment {
+  display: flex;
+  border-top: 1px solid #d9d9d9;
+  padding: 8px 3px 6px 3px;
+}
+
+.parent-comment .comment-writer {
+  float: left;
+  width: 132px;
+  padding-left: 5px;
+  margin-right: 33px;
+  margin-top: 3px;
+  line-height: 13px;
+}
+
+.parent-comment .comment-writer span {
+  position: relative;
+  font-size: 13px;
+}
+
+.parent-comment .comment-content {
+  float: left;
+  width: 690px;
+}
+
+.parent-comment .comment-content p {
+  line-height: 20px;
+}
+
+.parent-comment .comment-content p::after {
+  content: '';
+}
+
+.parent-comment .comment-write-date {
+  float: right;
+}
+
+.parent-comment .comment-write-date span {
+  float: left;
+  font-size: 12px;
+  color: #999;
+  vertical-align: top;
+  margin-top: 1px;
+}
+
+/* comment : 삭제 버튼 - S */
+
+.parent-comment .delete-btn {
+  border: none;
+  padding: 2px 3px;
+  cursor: pointer;
+  background-color: red;
+  color: rgb(245, 245, 245);
+  font-weight: bold;
+  margin-left: 10px;
+}
+
+.parent-comment .delete-btn:active {
+  box-shadow: inset 1px 1px 1.5px 1px rgba(0, 0, 0, 0.3);
+}
+
+/* comment : 삭제 버튼 - E */
+
+/* comment : parent - E */
+
+/* comment : children - S */
+.child-comment {
+  width: 80%;
+  background-color: #eaeaea;
+  display: flex;
+  justify-content: center;
+  margin-left: 10px;
+  margin: 5px 0px;
+}
+
+.child-comment .comment-writer {
+  float: left;
+  width: 68px;
+  padding-left: 5px;
+}
+
+.child-comment .comment-writer span {
+  position: relative;
+  font-size: 11px;
+}
+
+.child-comment .comment-content {
+  display: inline-flex;
+  align-items: center;
+  float: left;
+  width: 450px;
+}
+
+.child-comment .comment-content p {
+  line-height: 10px;
+  font-size: 12px;
+}
+
+.child-comment .comment-content span {
+  font-weight: 800;
+  margin-right: 5px;
+}
+
+.child-comment .comment-write-date {
+  float: right;
+  margin-right: 10px;
+}
+
+.child-comment .comment-write-date span {
+  float: left;
+  font-size: 11px;
+  color: #999;
+  vertical-align: top;
+  margin-top: 1px;
+}
+
+/* comment: 삭제 버튼 - S */
+.child-comment .delete-btn {
+  border: none;
+  padding: 2px 3px;
+  cursor: pointer;
+  background-color: red;
+  color: rgb(245, 245, 245);
+  font-weight: bold;
+}
+/* comment: 삭제 버튼 - E */
+
+/* comment : children - E */
+
+/* comment : 답글 버튼 - S */
+.reply-box-toggle {
+  display: inline-flex;
+  justify-content: flex-start;
+  align-items: center;
+  border: none;
+  cursor: pointer;
+  font-size: 10px;
+}
+
+.reply-box {
+  max-height: 0;
+  transition: transform 0.5 ease;
+  overflow: hidden;
+}
+
+.reply-box.visible {
+  max-height: 150px;
+  width: 85%;
+  padding: 5px 0px;
+  margin: 25px;
+  border: none;
+  border: 1px solid #8b8a8a;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.reply-box textarea {
+  resize: none;
+  width: 90%;
+  height: 100px;
+}
+
+.reply-box button {
+  cursor: pointer;
+  margin-left: 10px;
+  width: 50px;
+  height: 25px;
+  background-color: #7c7c7c;
+  color: rgb(255, 255, 255);
+}
+/* comment : 답글 버튼 - E */

--- a/front-server/src/components/CommentItem/style.css
+++ b/front-server/src/components/CommentItem/style.css
@@ -85,7 +85,7 @@ textarea:focus {
 
 .child-comment .comment-writer {
   float: left;
-  width: 68px;
+  width: 120px;
   padding-left: 5px;
 }
 

--- a/front-server/src/components/CommentList/index.tsx
+++ b/front-server/src/components/CommentList/index.tsx
@@ -1,0 +1,170 @@
+import CommentItem from 'components/CommentItem';
+import './style.css';
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { useParams } from 'react-router-dom';
+import { Comment } from 'types/interface';
+
+const CommentList = () => {
+  const { boardId, postId } = useParams();
+
+  const uuid = sessionStorage.getItem('uuid');
+
+  // state: 현재 페이지 //
+  const [currentPage, setCurrentPage] = useState<number>(0);
+
+  // state: 전체 페이지 //
+  const [totalPages, setTotalPages] = useState<number>(0);
+
+  // state : 페이지 그룹 //
+  const [pageGroup, setPageGroup] = useState<number>(0);
+
+  // state: 댓글 목록 //
+  const [comments, setComments] = useState<Comment[]>([]);
+
+  // state: 댓글 작성 - 내용 //
+  const [content, setContent] = useState<string>('');
+
+  const [totalElements, setTotalElements] = useState<number>(0);
+
+  // function: 페이지 목록 생성 //
+  const createPageArr = () => {
+    const arr: number[] = new Array(totalPages);
+    const first = (pageGroup - 1) * 5 + 1;
+    let last = pageGroup * 5;
+
+    if (last > totalPages) last = totalPages;
+
+    for (let i = first; i <= last; i++) {
+      arr[i] = i;
+    }
+    return arr;
+  };
+
+  // event-handler: 댓글 등록 이벤트 핸들러 //
+  const onAddCommentEventHandler = async () => {
+    try {
+      if (content.trim() == '') return;
+      const request = { postId: postId, content: content, writer: '작성자' };
+      await axios.post('/board-service/api/v1/comments', request);
+      setContent('');
+      return;
+    } catch (error) {
+      console.error('⚠️ 댓글 등록 중 오류 발생', error);
+    }
+  };
+
+  // comment : 페이지 목록 배열//
+  const pageArr = createPageArr();
+
+  // function: 이전 페이지 이동 함수 //
+  const prevPage = () => {
+    if (currentPage <= 0) return;
+
+    setCurrentPage((n: number) => n - 1);
+  };
+
+  // function: 다음 페이지 이동 함수 //
+  const nextPage = () => {
+    if (currentPage >= totalPages - 1) return;
+
+    setCurrentPage((n: number) => n + 1);
+  };
+
+  // function: 처음 페이지 이동 함수 //
+  const firstPage = () => {
+    setCurrentPage(0);
+  };
+
+  // function: 마지막 페이지 이동 함수 //
+  const lastPage = () => {
+    if (totalPages == 0) return;
+    setCurrentPage(totalPages - 1);
+  };
+
+  // function: 댓글 목록 조회 함수 //
+  const fetchComments = async () => {
+    try {
+      const response = await axios.get(`/board-service/api/v1/comments/${postId}`, {
+        params: { page: currentPage, size: 10 },
+      });
+
+      console.log(response);
+      const { dtoList, page, totalPages, totalElements } = response.data;
+      setCurrentPage(page);
+      setTotalPages(totalPages);
+      setTotalElements(totalElements);
+      setPageGroup(Math.ceil((page + 1) / 10));
+      console.log(dtoList);
+      setComments(dtoList);
+    } catch (error) {
+      console.error('⚠️ 채팅 목록 조회 오류 발생', error);
+    }
+  };
+
+  useEffect(() => {
+    fetchComments();
+  }, [currentPage]);
+
+  return (
+    <div className="comment-list-wrapper">
+      <div className="comment-list-count">
+        전체 댓글 <span style={{ fontWeight: '700', marginLeft: '5px' }}>{totalElements}</span>개
+      </div>
+      <div className="comment-list-container">
+        <div className="comment-write-box">
+          <div className="comment-write-content">
+            <textarea
+              placeholder="욕설이나 폭언은 자제 부탁드립니다."
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+            ></textarea>
+          </div>
+          <div className="comment-write-btn">
+            <button onClick={onAddCommentEventHandler}>등록</button>
+          </div>
+        </div>
+        <ul className="comment-list">
+          {comments.map((comment, index) => (
+            <div key={index}>
+              <li>
+                <CommentItem parentComment={comment} />
+              </li>
+              {comment.children &&
+                comment.children.map((child, index) => (
+                  <li key={index}>
+                    <CommentItem childComment={child} />
+                  </li>
+                ))}
+            </div>
+          ))}
+        </ul>
+        <div className="comment-list-pagination">
+          {totalPages !== 0 && (
+            <>
+              <button onClick={firstPage}>&lt;&lt;</button>
+              <button onClick={prevPage}>&lt;</button>
+
+              {pageArr.map((n: number) => (
+                <button
+                  key={n - 1}
+                  style={currentPage === n - 1 ? { textDecoration: 'underline' } : {}}
+                  onClick={() => {
+                    setCurrentPage(n - 1);
+                  }}
+                >
+                  {n}
+                </button>
+              ))}
+
+              <button onClick={nextPage}>&gt;</button>
+              <button onClick={lastPage}>&gt;&gt;</button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CommentList;

--- a/front-server/src/components/CommentList/index.tsx
+++ b/front-server/src/components/CommentList/index.tsx
@@ -6,9 +6,9 @@ import { useParams } from 'react-router-dom';
 import { Comment } from 'types/interface';
 
 const CommentList = () => {
-  const { boardId, postId } = useParams();
+  const { postId } = useParams();
 
-  const uuid = sessionStorage.getItem('uuid');
+  const uuid = sessionStorage.getItem('uuid') || '작성자';
 
   // state: 현재 페이지 //
   const [currentPage, setCurrentPage] = useState<number>(0);
@@ -45,9 +45,10 @@ const CommentList = () => {
   const onAddCommentEventHandler = async () => {
     try {
       if (content.trim() == '') return;
-      const request = { postId: postId, content: content, writer: '작성자' };
+      const request = { postId: postId, content: content, writer: uuid };
       await axios.post('/board-service/api/v1/comments', request);
       setContent('');
+      fetchComments();
       return;
     } catch (error) {
       console.error('⚠️ 댓글 등록 중 오류 발생', error);
@@ -128,12 +129,17 @@ const CommentList = () => {
           {comments.map((comment, index) => (
             <div key={index}>
               <li>
-                <CommentItem parentComment={comment} />
+                <CommentItem
+                  parentComment={comment}
+                  postId={Number(postId)}
+                  writer={uuid}
+                  fetchComments={fetchComments}
+                />
               </li>
               {comment.children &&
                 comment.children.map((child, index) => (
                   <li key={index}>
-                    <CommentItem childComment={child} />
+                    <CommentItem childComment={child} writer={uuid} fetchComments={fetchComments} />
                   </li>
                 ))}
             </div>

--- a/front-server/src/components/CommentList/style.css
+++ b/front-server/src/components/CommentList/style.css
@@ -1,0 +1,80 @@
+.comment-list-wrapper {
+  width: 100%;
+  height: 100%;
+}
+
+.comment-list-container {
+  min-height: 700px;
+  max-width: 1024px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.comment-list-count {
+  padding-left: 15px;
+}
+
+.comment-list-border {
+  border-top: 1px solid rgba(0, 0, 0, 0.5);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.5);
+}
+
+.comment-list {
+  margin-top: 20px;
+  padding: 5px 0px 15px 0px;
+  list-style: none;
+}
+
+.comment-write-box {
+  margin: 3px;
+  width: 100%;
+  height: 100%;
+
+  background-color: #eaeaea;
+  border: 1px solid rgba(0, 0, 0, 0.5);
+}
+
+.comment-write-content {
+  margin: 0 auto;
+  width: 80%;
+  height: 150px;
+  border: none;
+  padding: 10px;
+}
+
+.comment-write-content textarea {
+  width: 100%;
+  height: 100%;
+  resize: none;
+  padding: 10px;
+}
+
+.comment-list-pagination {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 30px;
+}
+
+.comment-list-pagination button {
+  cursor: pointer;
+  background-color: rgb(255, 255, 255);
+  margin: 5px;
+}
+
+.comment-write-btn {
+  display: flex;
+  justify-content: flex-end;
+  padding: 15px;
+}
+
+.comment-write-btn button {
+  cursor: pointer;
+  width: 80px;
+  height: 25px;
+  background-color: #7c7c7c;
+  color: rgb(255, 255, 255);
+}
+
+.comment-write-btn button:active {
+  box-shadow: inset 1px 1px 1.5px 1px rgba(0, 0, 0, 0.5);
+}

--- a/front-server/src/pages/Post/detail/index.tsx
+++ b/front-server/src/pages/Post/detail/index.tsx
@@ -4,6 +4,7 @@ import axios from 'axios';
 import { useEffect, useState } from 'react';
 import TextEditor from 'components/Quill/Detail';
 import CommentList from 'components/CommentList';
+import { getNicknameRequest } from 'apis';
 
 interface postDetail {
   boardTitle: string;
@@ -22,6 +23,7 @@ interface postDetail {
 const PostDetail = () => {
   const navigator = useNavigate();
   const { boardId, postId } = useParams();
+  const uuid = sessionStorage.getItem('uuid');
 
   // state: 게시판 제목 //
   const [boardTitle, setBoardTitle] = useState<string>('');
@@ -41,8 +43,10 @@ const PostDetail = () => {
   // state: 게시글 조회수 //
   const [click, setClick] = useState<number>(0);
 
+  // state: 작성자 여부 확인 //
+  const [isWriter, setIsWriter] = useState<boolean>(false);
+
   // comment: 수정 + 삭제 관련 - 해당 회원만 삭제 수정이 가능하도록 로직 수정 예정 //
-  // event-handler: 게시글 수정 버튼 핸들러 //
 
   // event-handler: 게시글 삭제 버튼 핸들러 //
   const onPostDeleteBtnHandler = async () => {
@@ -62,6 +66,21 @@ const PostDetail = () => {
     }
   };
 
+  // function: 작성자 여부 확인 함수 //
+  const confirmWriter = async (postWriter: string) => {
+    if (!uuid) {
+      return;
+    }
+
+    const nickname = await getNicknameRequest(uuid);
+
+    if (postWriter === nickname) {
+      setIsWriter(true);
+    } else {
+      setIsWriter(false);
+    }
+  };
+
   // function: 게시글 상세 정보 조회 함수 //
   const fetchPost = async () => {
     try {
@@ -74,6 +93,7 @@ const PostDetail = () => {
       setClick(click);
       setCreatedAt(createdAt);
       setWriter(writer);
+      await confirmWriter(writer);
     } catch (error) {
       console.error('⚠️ 게시글 조회 시 오류 발생', error);
     }
@@ -110,17 +130,21 @@ const PostDetail = () => {
           >
             목록
           </button>
-          <button
-            className="post-update-btn"
-            onClick={() => {
-              navigator(`/post/${boardId}/${postId}/update`);
-            }}
-          >
-            수정
-          </button>
-          <button className="post-delete-btn" onClick={onPostDeleteBtnHandler}>
-            삭제
-          </button>
+          {isWriter && (
+            <>
+              <button
+                className="post-update-btn"
+                onClick={() => {
+                  navigator(`/post/${boardId}/${postId}/update`);
+                }}
+              >
+                수정
+              </button>
+              <button className="post-delete-btn" onClick={onPostDeleteBtnHandler}>
+                삭제
+              </button>
+            </>
+          )}
         </div>
         <CommentList></CommentList>
       </div>

--- a/front-server/src/pages/Post/detail/index.tsx
+++ b/front-server/src/pages/Post/detail/index.tsx
@@ -3,6 +3,7 @@ import './style.css';
 import axios from 'axios';
 import { useEffect, useState } from 'react';
 import TextEditor from 'components/Quill/Detail';
+import CommentList from 'components/CommentList';
 
 interface postDetail {
   boardTitle: string;
@@ -96,8 +97,6 @@ const PostDetail = () => {
             </div>
             <div className="post-detail-box-left">
               <p>조회 {click}</p>
-              <p>|</p>
-              <p>댓글</p>
             </div>
           </div>
         </div>
@@ -123,6 +122,7 @@ const PostDetail = () => {
             삭제
           </button>
         </div>
+        <CommentList></CommentList>
       </div>
     </div>
   );

--- a/front-server/src/pages/Post/main/index.tsx
+++ b/front-server/src/pages/Post/main/index.tsx
@@ -76,7 +76,6 @@ const MainBoard = () => {
       });
 
       const { dtoList, page, boardTitle, totalPages } = response.data;
-      console.log(response.data);
       setCurrentPage(page);
       setPosts(dtoList);
       setTitle(boardTitle);

--- a/front-server/src/pages/Post/write/index.tsx
+++ b/front-server/src/pages/Post/write/index.tsx
@@ -22,7 +22,7 @@ const PostWrite = () => {
     const request = {
       title: title,
       content: htmlContent,
-      uuid: '58e681e6-aaca-46a7-b186-5e48a5a24c81',
+      uuid: uuid,
     };
     //axios 요청
     try {

--- a/front-server/src/types/interface/comment.ts
+++ b/front-server/src/types/interface/comment.ts
@@ -1,0 +1,7 @@
+export default interface Comment {
+  id: number;
+  writer: string;
+  content: string;
+  createdAt: string;
+  children: Comment[];
+}

--- a/front-server/src/types/interface/index.ts
+++ b/front-server/src/types/interface/index.ts
@@ -3,5 +3,15 @@ import Pageable from './pageable.interface';
 import UserInfo from './user-info.interface';
 import { UserSubscription, Store, PushMessage } from './push-message';
 import PostListItem from './post-list-item';
+import Comment from './comment';
 
-export type { MessageType, Pageable, UserInfo, UserSubscription, Store, PushMessage, PostListItem };
+export type {
+  MessageType,
+  Pageable,
+  UserInfo,
+  UserSubscription,
+  Store,
+  PushMessage,
+  PostListItem,
+  Comment,
+};

--- a/user-service/src/main/java/com/wesell/userservice/controller/UserController.java
+++ b/user-service/src/main/java/com/wesell/userservice/controller/UserController.java
@@ -44,4 +44,10 @@ public class UserController {
         return ResponseEntity.ok(userService.updateDealCount(uuid));
     }
 
+    // 닉네임 조회
+    @GetMapping("{uuid}/nickname")
+    public ResponseEntity getNickname(@PathVariable String uuid){
+        return ResponseEntity.ok(userService.getNicknameByUuid(uuid));
+    }
+
 }


### PR DESCRIPTION
![](https://velog.velcdn.com/images/hyensukim/post/9f74fe09-2795-4e73-9b70-83e41e9f261c/image.png)

## 구현한 부분
- 게시글 대댓글 조회
- 게시글 대댓글 등록
- 게시글 대댓글 삭제
- 게시글 댓글 관련 기능 추가 구현

### 추가 구현 부분
- 댓글 작성 시 로그인 회원 닉네임 등록
- 작성자만 수정,삭제 가능하도록 제한
- 댓글 작성 및 삭제 후 프론트에서 데이터 바로 반영되도록 구현
